### PR TITLE
Support configurable base path for GitHub Pages and Docker deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+        env:
+          BASE_PATH: /retirement-planner/
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,6 @@ import tailwindcss from '@tailwindcss/vite'
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/',
+  base: process.env.BASE_PATH || '/',
   plugins: [react(), tailwindcss()],
 })


### PR DESCRIPTION
Use BASE_PATH environment variable to set Vite base path, defaulting
to '/' for Docker. GitHub Actions workflow sets BASE_PATH=/retirement-planner/
for GitHub Pages deployment.