### PR TITLE
feat: add Income Streams for flexible retirement income modeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Tests cover:
 
 ### Contributors
 - **bwillem** ([@bguenther3](mailto:bguenther3@gmail.com)) - Multi-country support (Canada)
-- **Josh Smith** ([josh.smith@stopsoldiersuicide.org](mailto:josh.smith@stopsoldiersuicide.org)) - Configurable account withdrawal age
+- **Josh Smith** ([smithgotsurf@gmail.com](mailto:smithgotsurf@gmail.com)) - Configurable account withdrawal age
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Tests cover:
 
 ### Contributors
 - **bwillem** ([@bguenther3](mailto:bguenther3@gmail.com)) - Multi-country support (Canada)
-- **Josh Smith** ([smithgotsurf@gmail.com](mailto:smithgotsurf@gmail.com)) - Configurable account withdrawal age
+- **Josh Smith** ([smithgotsurf@gmail.com](mailto:smithgotsurf@gmail.com)) - Configurable account withdrawal age, Income Streams feature
 
 ## Disclaimer
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1711,6 +1712,7 @@
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1721,6 +1723,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1793,6 +1796,7 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -1936,24 +1940,37 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.7.tgz",
+      "integrity": "sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2044,6 +2061,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2062,9 +2080,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2186,6 +2204,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2574,6 +2593,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3435,9 +3455,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3580,6 +3600,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3606,6 +3627,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3647,6 +3669,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3656,6 +3679,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3675,6 +3699,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3737,7 +3762,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -3949,6 +3975,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3982,6 +4009,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4111,6 +4139,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4232,6 +4261,7 @@
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
-import { Account, Profile, Assumptions } from './types';
-import { DEFAULT_PROFILE, DEFAULT_ASSUMPTIONS } from './utils/constants';
+import { Account, Profile, Assumptions, IncomeStream } from './types';
+import { DEFAULT_PROFILE, DEFAULT_ASSUMPTIONS, DEFAULT_INCOME_STREAMS } from './utils/constants';
 import { useRetirementCalc } from './hooks/useRetirementCalc';
 import { useLocalStorage, useDarkMode } from './hooks/useLocalStorage';
 import { CountryProvider, useCountry } from './contexts/CountryContext';
@@ -10,6 +10,7 @@ import { Layout } from './components/Layout';
 import { AccountList } from './components/AccountList';
 import { ProfileForm } from './components/ProfileForm';
 import { AssumptionsForm } from './components/AssumptionsForm';
+import { IncomeStreamList } from './components/IncomeStreamList';
 import { SummaryCards } from './components/SummaryCards';
 import { ChartAccumulation } from './components/ChartAccumulation';
 import { ChartDrawdown } from './components/ChartDrawdown';
@@ -136,6 +137,11 @@ function AppContent() {
     DEFAULT_ASSUMPTIONS
   );
 
+  const [incomeStreams, setIncomeStreams, resetIncomeStreams] = useLocalStorage<IncomeStream[]>(
+    'retirement-planner-income-streams',
+    DEFAULT_INCOME_STREAMS
+  );
+
   // Dark mode
   const [isDarkMode, toggleDarkMode] = useDarkMode();
 
@@ -144,7 +150,7 @@ function AppContent() {
   const [expandedSection, setExpandedSection] = useState<string | null>('accounts');
   const [showResetConfirm, setShowResetConfirm] = useState(false);
 
-  const { accumulation, retirement } = useRetirementCalc(accounts, profile, assumptions, countryConfig);
+  const { accumulation, retirement } = useRetirementCalc(accounts, profile, assumptions, countryConfig, incomeStreams);
 
   const handleAddAccount = (account: Account) => {
     setAccounts(prev => [...prev, account]);
@@ -160,6 +166,20 @@ function AppContent() {
     setAccounts(prev => prev.filter(acc => acc.id !== id));
   };
 
+  const handleAddIncomeStream = (stream: IncomeStream) => {
+    setIncomeStreams(prev => [...prev, stream]);
+  };
+
+  const handleUpdateIncomeStream = (updatedStream: IncomeStream) => {
+    setIncomeStreams(prev =>
+      prev.map(s => (s.id === updatedStream.id ? updatedStream : s))
+    );
+  };
+
+  const handleDeleteIncomeStream = (id: string) => {
+    setIncomeStreams(prev => prev.filter(s => s.id !== id));
+  };
+
   const toggleSection = (section: string) => {
     setExpandedSection(prev => (prev === section ? null : section));
   };
@@ -172,10 +192,11 @@ function AppContent() {
     resetAccounts();
     resetProfile();
     resetAssumptions();
+    resetIncomeStreams();
     setShowResetConfirm(false);
     // Force reload to get fresh default accounts with new UUIDs
     window.location.reload();
-  }, [resetAccounts, resetProfile, resetAssumptions]);
+  }, [resetAccounts, resetProfile, resetAssumptions, resetIncomeStreams]);
 
   const cancelReset = useCallback(() => {
     setShowResetConfirm(false);
@@ -249,6 +270,7 @@ function AppContent() {
                 <AccountList
                   accounts={accounts}
                   profile={profile}
+                  countryConfig={countryConfig}
                   onAdd={handleAddAccount}
                   onUpdate={handleUpdateAccount}
                   onDelete={handleDeleteAccount}
@@ -278,6 +300,36 @@ function AppContent() {
             {expandedSection === 'profile' && (
               <div className="px-4 pb-4">
                 <ProfileForm profile={profile} onChange={setProfile} />
+              </div>
+            )}
+          </div>
+
+          {/* Income Streams Section */}
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+            <button
+              onClick={() => toggleSection('incomeStreams')}
+              className="w-full px-4 py-3 flex justify-between items-center hover:bg-gray-50 dark:hover:bg-gray-700 rounded-t-lg"
+            >
+              <span className="font-medium text-gray-900 dark:text-white">Income Streams</span>
+              <svg
+                className={`w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform ${
+                  expandedSection === 'incomeStreams' ? 'rotate-180' : ''
+                }`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+            {expandedSection === 'incomeStreams' && (
+              <div className="px-4 pb-4">
+                <IncomeStreamList
+                  incomeStreams={incomeStreams}
+                  onAdd={handleAddIncomeStream}
+                  onUpdate={handleUpdateIncomeStream}
+                  onDelete={handleDeleteIncomeStream}
+                />
               </div>
             )}
           </div>
@@ -405,7 +457,7 @@ function AppContent() {
                     <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
                       Annual Retirement Income
                     </h3>
-                    <ChartIncome result={retirement} isDarkMode={isDarkMode} />
+                    <ChartIncome result={retirement} incomeStreams={incomeStreams} isDarkMode={isDarkMode} />
                   </div>
 
                   <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
@@ -415,7 +467,7 @@ function AppContent() {
                     <ChartTax result={retirement} isDarkMode={isDarkMode} />
                   </div>
 
-                  <DataTableWithdrawal accounts={accounts} result={retirement} />
+                  <DataTableWithdrawal accounts={accounts} result={retirement} incomeStreams={incomeStreams} />
                 </div>
               )}
 
@@ -444,6 +496,11 @@ function App() {
       ...DEFAULT_PROFILE,
       ...defaultProfile,
     }));
+
+    // Reset income streams — default SS for US, empty for Canada
+    localStorage.setItem('retirement-planner-income-streams',
+      JSON.stringify(newCountry === 'US' ? DEFAULT_INCOME_STREAMS : [])
+    );
 
     // Force reload to reinitialize with new country defaults
     window.location.reload();

--- a/src/components/ChartIncome.tsx
+++ b/src/components/ChartIncome.tsx
@@ -10,11 +10,12 @@ import {
   Legend,
   ReferenceLine,
 } from 'recharts';
-import { RetirementResult } from '../types';
+import { RetirementResult, IncomeStream } from '../types';
 import { CHART_COLORS } from '../utils/constants';
 
 interface ChartIncomeProps {
   result: RetirementResult;
+  incomeStreams?: IncomeStream[];
   isDarkMode?: boolean;
 }
 
@@ -57,12 +58,12 @@ function CustomTooltip({ active, payload, label, result }: CustomTooltipProps) {
           <span style={{ color: CHART_COLORS.pretax }}>Withdrawals:</span>
           <span className="font-medium text-gray-900 dark:text-white">{formatTooltipValue(yearData.totalWithdrawal)}</span>
         </div>
-        {yearData.socialSecurityIncome > 0 && (
-          <div className="flex justify-between gap-4">
-            <span style={{ color: CHART_COLORS.socialSecurity }}>Social Security:</span>
-            <span className="font-medium text-gray-900 dark:text-white">{formatTooltipValue(yearData.socialSecurityIncome)}</span>
+        {payload?.filter(p => ['socialSecurity', 'pension', 'otherIncome', 'taxFreeIncome'].includes(p.dataKey) && p.value > 0).map(p => (
+          <div key={p.dataKey} className="flex justify-between gap-4">
+            <span style={{ color: p.color }}>{p.name}:</span>
+            <span className="font-medium text-gray-900 dark:text-white">{formatTooltipValue(p.value)}</span>
           </div>
-        )}
+        ))}
         <div className="flex justify-between gap-4 border-t border-gray-200 dark:border-gray-600 pt-1 mt-1">
           <span className="text-gray-600 dark:text-gray-400">Gross Income:</span>
           <span className="font-medium text-gray-900 dark:text-white">{formatTooltipValue(yearData.grossIncome)}</span>
@@ -85,22 +86,56 @@ function CustomTooltip({ active, payload, label, result }: CustomTooltipProps) {
   );
 }
 
-export function ChartIncome({ result, isDarkMode = false }: ChartIncomeProps) {
+export function ChartIncome({ result, incomeStreams = [], isDarkMode = false }: ChartIncomeProps) {
   // Colors based on dark mode
   const gridColor = isDarkMode ? '#374151' : '#e5e7eb';
   const tickColor = isDarkMode ? '#9ca3af' : '#6b7280';
   const tickLineColor = isDarkMode ? '#4b5563' : '#d1d5db';
+  // Determine which income stream bands have data
+  const hasPensionStreams = incomeStreams.some(s => s.taxTreatment === 'fully_taxable');
+  const hasOtherIncomeStreams = incomeStreams.some(s => s.taxTreatment === 'other_income');
+  const hasTaxFreeStreams = incomeStreams.some(s => s.taxTreatment === 'tax_free');
+
   // Transform data for the chart
   // Show gross income as stacked bars (positive), taxes as separate negative bar
-  const chartData = result.yearlyWithdrawals.map(year => ({
-    age: year.age,
-    withdrawals: year.totalWithdrawal,
-    socialSecurity: year.socialSecurityIncome,
-    taxes: year.totalTax, // Keep positive for separate display
-    afterTax: year.afterTaxIncome,
-    gross: year.grossIncome,
-    // For the net visualization, we'll show after-tax as a line
-  }));
+  const chartData = result.yearlyWithdrawals.map(year => {
+    let ssIncome = 0;
+    let pensionIncome = 0;
+    let otherIncome = 0;
+    let taxFreeIncome = 0;
+
+    // Split incomeStreamIncome proportionally by tax treatment
+    const activeStreams = incomeStreams.filter(s => year.age >= s.startAge && (!s.endAge || year.age <= s.endAge));
+    const totalMonthly = activeStreams.reduce((sum, s) => sum + s.monthlyAmount, 0);
+
+    if (totalMonthly > 0 && year.incomeStreamIncome > 0) {
+      for (const stream of activeStreams) {
+        const ratio = stream.monthlyAmount / totalMonthly;
+        const streamAmount = year.incomeStreamIncome * ratio;
+        switch (stream.taxTreatment) {
+          case 'social_security': ssIncome += streamAmount; break;
+          case 'fully_taxable': pensionIncome += streamAmount; break;
+          case 'other_income': otherIncome += streamAmount; break;
+          case 'tax_free': taxFreeIncome += streamAmount; break;
+        }
+      }
+    }
+
+    // Government benefits (Canada CPP/OAS) go into the SS band
+    ssIncome += year.governmentBenefitIncome;
+
+    return {
+      age: year.age,
+      withdrawals: year.totalWithdrawal,
+      socialSecurity: ssIncome,
+      pension: pensionIncome,
+      otherIncome: otherIncome,
+      taxFreeIncome: taxFreeIncome,
+      taxes: year.totalTax,
+      afterTax: year.afterTaxIncome,
+      gross: year.grossIncome,
+    };
+  });
 
   return (
     <div className="w-full h-80 touch-pan-y">
@@ -141,6 +176,33 @@ export function ChartIncome({ result, isDarkMode = false }: ChartIncomeProps) {
             fill={CHART_COLORS.socialSecurity}
             fillOpacity={0.8}
           />
+          {hasPensionStreams && (
+            <Bar
+              dataKey="pension"
+              name="Pension"
+              stackId="income"
+              fill={CHART_COLORS.pension}
+              fillOpacity={0.8}
+            />
+          )}
+          {hasOtherIncomeStreams && (
+            <Bar
+              dataKey="otherIncome"
+              name="Other Income"
+              stackId="income"
+              fill={CHART_COLORS.otherIncome}
+              fillOpacity={0.8}
+            />
+          )}
+          {hasTaxFreeStreams && (
+            <Bar
+              dataKey="taxFreeIncome"
+              name="Tax-Free Income"
+              stackId="income"
+              fill={CHART_COLORS.taxFreeIncome}
+              fillOpacity={0.8}
+            />
+          )}
           {/* After-tax income line - the key metric */}
           <Line
             type="monotone"

--- a/src/components/DataTableWithdrawal.tsx
+++ b/src/components/DataTableWithdrawal.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
-import { Account, RetirementResult, getTaxTreatment } from '../types';
+import { Account, RetirementResult, IncomeStream, IncomeTaxTreatment, getTaxTreatment } from '../types';
+import { CHART_COLORS } from '../utils/constants';
 
 interface DataTableWithdrawalProps {
   accounts: Account[];
   result: RetirementResult;
+  incomeStreams?: IncomeStream[];
 }
 
 function formatCurrency(value: number): string {
@@ -19,9 +21,9 @@ function formatPercent(value: number): string {
   return `${(value * 100).toFixed(1)}%`;
 }
 
-type ViewMode = 'income' | 'withdrawals' | 'balances' | 'taxes';
+type ViewMode = 'income' | 'withdrawals' | 'balances' | 'taxes' | 'incomeStreams';
 
-export function DataTableWithdrawal({ accounts, result }: DataTableWithdrawalProps) {
+export function DataTableWithdrawal({ accounts, result, incomeStreams = [] }: DataTableWithdrawalProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>('income');
   const [expandedPenaltyRows, setExpandedPenaltyRows] = useState<Set<number>>(new Set());
@@ -40,7 +42,7 @@ export function DataTableWithdrawal({ accounts, result }: DataTableWithdrawalPro
 
   if (!result.yearlyWithdrawals.length) return null;
 
-  // Get color class based on tax treatment
+  // Get color class based on account tax treatment
   const getColorClass = (accountType: Account['type']): string => {
     const treatment = getTaxTreatment(accountType);
     switch (treatment) {
@@ -48,6 +50,16 @@ export function DataTableWithdrawal({ accounts, result }: DataTableWithdrawalPro
       case 'roth': return 'text-green-600 dark:text-green-400';
       case 'taxable': return 'text-amber-600 dark:text-amber-400';
       case 'hsa': return 'text-purple-600 dark:text-purple-400';
+    }
+  };
+
+  // Get inline color for income stream tax treatment
+  const getStreamColor = (taxTreatment: IncomeTaxTreatment): string => {
+    switch (taxTreatment) {
+      case 'social_security': return CHART_COLORS.socialSecurity;
+      case 'fully_taxable': return CHART_COLORS.pension;
+      case 'other_income': return CHART_COLORS.otherIncome;
+      case 'tax_free': return CHART_COLORS.taxFreeIncome;
     }
   };
 
@@ -122,6 +134,16 @@ export function DataTableWithdrawal({ accounts, result }: DataTableWithdrawalPro
             >
               Tax Details
             </button>
+            <button
+              onClick={() => setViewMode('incomeStreams')}
+              className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px whitespace-nowrap ${
+                viewMode === 'incomeStreams'
+                  ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                  : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+              }`}
+            >
+              Income Streams
+            </button>
           </div>
 
           <div className="overflow-x-auto">
@@ -132,7 +154,7 @@ export function DataTableWithdrawal({ accounts, result }: DataTableWithdrawalPro
                     <th className="text-left py-2 px-2 font-medium text-gray-700 dark:text-gray-300 sticky left-0 bg-white dark:bg-gray-800">Age</th>
                     <th className="text-right py-2 px-2 font-medium text-gray-700 dark:text-gray-300">Target Spending</th>
                     <th className="text-right py-2 px-2 font-medium text-gray-700 dark:text-gray-300">Withdrawals</th>
-                    <th className="text-right py-2 px-2 font-medium text-indigo-600 dark:text-indigo-400">Social Security</th>
+                    <th className="text-right py-2 px-2 font-medium" style={{ color: CHART_COLORS.retirementIncome }}>Retirement Income</th>
                     <th className="text-right py-2 px-2 font-medium text-gray-700 dark:text-gray-300">Gross Income</th>
                     <th className="text-right py-2 px-2 font-medium text-red-600 dark:text-red-400">Total Taxes</th>
                     <th className="text-right py-2 px-2 font-medium text-teal-600 dark:text-teal-400">After-Tax Income</th>
@@ -144,8 +166,8 @@ export function DataTableWithdrawal({ accounts, result }: DataTableWithdrawalPro
                       <td className="py-2 px-2 font-medium text-gray-900 dark:text-white sticky left-0 bg-white dark:bg-gray-800">{yearData.age}</td>
                       <td className="py-2 px-2 text-right font-mono text-gray-600 dark:text-gray-400">{formatCurrency(yearData.targetSpending)}</td>
                       <td className="py-2 px-2 text-right font-mono text-gray-900 dark:text-white">{formatCurrency(yearData.totalWithdrawal)}</td>
-                      <td className="py-2 px-2 text-right font-mono text-indigo-600 dark:text-indigo-400">
-                        {yearData.socialSecurityIncome > 0 ? formatCurrency(yearData.socialSecurityIncome) : '-'}
+                      <td className="py-2 px-2 text-right font-mono" style={{ color: CHART_COLORS.retirementIncome }}>
+                        {(yearData.governmentBenefitIncome + yearData.incomeStreamIncome) > 0 ? formatCurrency(yearData.governmentBenefitIncome + yearData.incomeStreamIncome) : '-'}
                       </td>
                       <td className="py-2 px-2 text-right font-mono text-gray-900 dark:text-white">{formatCurrency(yearData.grossIncome)}</td>
                       <td className="py-2 px-2 text-right font-mono text-red-600 dark:text-red-400">{formatCurrency(yearData.totalTax)}</td>
@@ -160,8 +182,8 @@ export function DataTableWithdrawal({ accounts, result }: DataTableWithdrawalPro
                     <td className="py-2 px-2 text-right font-mono font-medium text-gray-900 dark:text-white">
                       {formatCurrency(result.yearlyWithdrawals.reduce((sum, y) => sum + y.totalWithdrawal, 0))}
                     </td>
-                    <td className="py-2 px-2 text-right font-mono font-medium text-indigo-600 dark:text-indigo-400">
-                      {formatCurrency(result.yearlyWithdrawals.reduce((sum, y) => sum + y.socialSecurityIncome, 0))}
+                    <td className="py-2 px-2 text-right font-mono font-medium" style={{ color: CHART_COLORS.retirementIncome }}>
+                      {formatCurrency(result.yearlyWithdrawals.reduce((sum, y) => sum + y.governmentBenefitIncome + y.incomeStreamIncome, 0))}
                     </td>
                     <td className="py-2 px-2 text-right font-mono font-medium text-gray-900 dark:text-white">
                       {formatCurrency(result.yearlyWithdrawals.reduce((sum, y) => sum + y.grossIncome, 0))}
@@ -337,6 +359,67 @@ export function DataTableWithdrawal({ accounts, result }: DataTableWithdrawalPro
                 </tfoot>
               </table>
             )}
+
+            {viewMode === 'incomeStreams' && incomeStreams.length > 0 && (
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-200 dark:border-gray-700">
+                    <th className="text-left py-2 px-2 font-medium text-gray-700 dark:text-gray-300 sticky left-0 bg-white dark:bg-gray-800">Age</th>
+                    {incomeStreams.map(stream => (
+                      <th key={stream.id} className="text-right py-2 px-2 font-medium" style={{ color: getStreamColor(stream.taxTreatment) }}>
+                        {stream.name}
+                      </th>
+                    ))}
+                    {result.yearlyWithdrawals.some(y => y.governmentBenefitIncome > 0) && (
+                      <th className="text-right py-2 px-2 font-medium" style={{ color: CHART_COLORS.socialSecurity }}>
+                        Gov. Benefits
+                      </th>
+                    )}
+                    <th className="text-right py-2 px-2 font-medium text-gray-700 dark:text-gray-300">Total</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.yearlyWithdrawals.map((yearData) => {
+                    const activeStreams = incomeStreams.filter(s => yearData.age >= s.startAge);
+                    const totalMonthly = activeStreams.reduce((sum, s) => sum + s.monthlyAmount, 0);
+
+                    return (
+                      <tr key={yearData.age} className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                        <td className="py-2 px-2 font-medium text-gray-900 dark:text-white sticky left-0 bg-white dark:bg-gray-800">{yearData.age}</td>
+                        {incomeStreams.map(stream => {
+                          if (yearData.age < stream.startAge || totalMonthly === 0) {
+                            return <td key={stream.id} className="py-2 px-2 text-right font-mono text-gray-400 dark:text-gray-600">-</td>;
+                          }
+                          const ratio = stream.monthlyAmount / totalMonthly;
+                          const amount = yearData.incomeStreamIncome * ratio;
+                          return (
+                            <td key={stream.id} className="py-2 px-2 text-right font-mono" style={{ color: getStreamColor(stream.taxTreatment) }}>
+                              {formatCurrency(amount)}
+                            </td>
+                          );
+                        })}
+                        {result.yearlyWithdrawals.some(y => y.governmentBenefitIncome > 0) && (
+                          <td className="py-2 px-2 text-right font-mono text-gray-600 dark:text-gray-400">
+                            {yearData.governmentBenefitIncome > 0 ? formatCurrency(yearData.governmentBenefitIncome) : '-'}
+                          </td>
+                        )}
+                        <td className="py-2 px-2 text-right font-mono font-medium text-gray-900 dark:text-white">
+                          {(yearData.governmentBenefitIncome + yearData.incomeStreamIncome) > 0
+                            ? formatCurrency(yearData.governmentBenefitIncome + yearData.incomeStreamIncome)
+                            : '-'}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            )}
+
+            {viewMode === 'incomeStreams' && incomeStreams.length === 0 && (
+              <p className="text-gray-500 dark:text-gray-400 text-sm py-8 text-center">
+                No income streams configured. Add Social Security, pensions, or other income in the Income Streams panel.
+              </p>
+            )}
           </div>
 
           {/* Legend */}
@@ -358,8 +441,20 @@ export function DataTableWithdrawal({ accounts, result }: DataTableWithdrawalPro
               <span className="text-gray-600 dark:text-gray-400">HSA</span>
             </div>
             <div className="flex items-center gap-1">
-              <span className="w-3 h-3 rounded bg-indigo-500"></span>
+              <span className="w-3 h-3 rounded" style={{ backgroundColor: CHART_COLORS.socialSecurity }}></span>
               <span className="text-gray-600 dark:text-gray-400">Social Security</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <span className="w-3 h-3 rounded" style={{ backgroundColor: CHART_COLORS.pension }}></span>
+              <span className="text-gray-600 dark:text-gray-400">Pension</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <span className="w-3 h-3 rounded" style={{ backgroundColor: CHART_COLORS.otherIncome }}></span>
+              <span className="text-gray-600 dark:text-gray-400">Other Income</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <span className="w-3 h-3 rounded" style={{ backgroundColor: CHART_COLORS.taxFreeIncome }}></span>
+              <span className="text-gray-600 dark:text-gray-400">Tax-Free Income</span>
             </div>
           </div>
         </div>

--- a/src/components/IncomeStreamForm.tsx
+++ b/src/components/IncomeStreamForm.tsx
@@ -1,0 +1,179 @@
+import { useState } from 'react';
+import { IncomeStream, IncomeTaxTreatment, getIncomeTaxTreatmentLabel } from '../types';
+import { NumberInput } from './NumberInput';
+import { v4 as uuidv4 } from 'uuid';
+
+interface IncomeStreamFormProps {
+  incomeStream?: IncomeStream;
+  onSave: (stream: IncomeStream) => void;
+  onCancel: () => void;
+}
+
+const inputClassName = "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 dark:text-white";
+const inputErrorClassName = "w-full px-3 py-2 border border-red-500 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 dark:text-white";
+
+const TAX_TREATMENTS: IncomeTaxTreatment[] = ['social_security', 'fully_taxable', 'other_income', 'tax_free'];
+
+export function IncomeStreamForm({ incomeStream, onSave, onCancel }: IncomeStreamFormProps) {
+  const [formData, setFormData] = useState<Omit<IncomeStream, 'id'>>(() => {
+    if (incomeStream) {
+      const { id: _id, ...rest } = incomeStream;
+      void _id;
+      return rest;
+    }
+    return {
+      name: '',
+      monthlyAmount: 0,
+      startAge: 67,
+      taxTreatment: 'social_security',
+    };
+  });
+
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const handleChange = (field: keyof Omit<IncomeStream, 'id'>, value: string | number) => {
+    setFormData(prev => ({ ...prev, [field]: value }));
+    if (errors[field]) {
+      setErrors(prev => {
+        const newErrors = { ...prev };
+        delete newErrors[field];
+        return newErrors;
+      });
+    }
+  };
+
+  const validate = (): boolean => {
+    const newErrors: Record<string, string> = {};
+    if (!formData.name.trim()) {
+      newErrors.name = 'Name is required';
+    }
+    if (formData.monthlyAmount <= 0) {
+      newErrors.monthlyAmount = 'Monthly amount must be greater than 0';
+    }
+    if (formData.startAge < 0 || formData.startAge > 120) {
+      newErrors.startAge = 'Start age must be between 0 and 120';
+    }
+    if (formData.endAge !== undefined && formData.endAge < formData.startAge) {
+      newErrors.endAge = 'End age must be at or after start age';
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validate()) return;
+    onSave({
+      id: incomeStream?.id || uuidv4(),
+      ...formData,
+    });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Name *
+        </label>
+        <input
+          type="text"
+          value={formData.name}
+          onChange={(e) => handleChange('name', e.target.value)}
+          placeholder="e.g., Social Security, NC State Pension"
+          className={errors.name ? inputErrorClassName : inputClassName}
+        />
+        {errors.name && <p className="text-red-500 text-xs mt-1">{errors.name}</p>}
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Monthly Benefit ($)
+          </label>
+          <NumberInput
+            value={formData.monthlyAmount}
+            onChange={(val) => handleChange('monthlyAmount', val)}
+            min={0}
+            defaultValue={0}
+            className={errors.monthlyAmount ? inputErrorClassName : inputClassName}
+          />
+          {errors.monthlyAmount && <p className="text-red-500 text-xs mt-1">{errors.monthlyAmount}</p>}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Start Age
+          </label>
+          <NumberInput
+            value={formData.startAge}
+            onChange={(val) => handleChange('startAge', val)}
+            min={0}
+            max={120}
+            defaultValue={67}
+            className={errors.startAge ? inputErrorClassName : inputClassName}
+          />
+          {errors.startAge && <p className="text-red-500 text-xs mt-1">{errors.startAge}</p>}
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          End Age <span className="text-gray-400 font-normal">(optional — leave blank for lifetime)</span>
+        </label>
+        <input
+          type="number"
+          value={formData.endAge ?? ''}
+          onChange={(e) => {
+            const val = e.target.value === '' ? undefined : Number(e.target.value);
+            setFormData(prev => ({ ...prev, endAge: val }));
+            if (errors.endAge) {
+              setErrors(prev => {
+                const newErrors = { ...prev };
+                delete newErrors.endAge;
+                return newErrors;
+              });
+            }
+          }}
+          min={0}
+          max={120}
+          placeholder="e.g., 62"
+          className={errors.endAge ? inputErrorClassName : inputClassName}
+        />
+        {errors.endAge && <p className="text-red-500 text-xs mt-1">{errors.endAge}</p>}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+          Tax Treatment
+        </label>
+        <select
+          value={formData.taxTreatment}
+          onChange={(e) => handleChange('taxTreatment', e.target.value as IncomeTaxTreatment)}
+          className={inputClassName}
+        >
+          {TAX_TREATMENTS.map(treatment => (
+            <option key={treatment} value={treatment}>
+              {getIncomeTaxTreatmentLabel(treatment)}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex justify-end gap-3 pt-4">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-600 border border-gray-300 dark:border-gray-500 rounded-md hover:bg-gray-50 dark:hover:bg-gray-500"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700"
+        >
+          {incomeStream ? 'Update' : 'Add Income Stream'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/IncomeStreamForm.tsx
+++ b/src/components/IncomeStreamForm.tsx
@@ -14,6 +14,13 @@ const inputErrorClassName = "w-full px-3 py-2 border border-red-500 rounded-md s
 
 const TAX_TREATMENTS: IncomeTaxTreatment[] = ['social_security', 'fully_taxable', 'other_income', 'tax_free'];
 
+const TAX_TREATMENT_DESCRIPTIONS: Record<IncomeTaxTreatment, string> = {
+  social_security: '85% taxable at your ordinary income rate',
+  fully_taxable: '100% taxable as ordinary income',
+  other_income: '100% taxable as ordinary income',
+  tax_free: 'Not included in taxable income (e.g., VA disability)',
+};
+
 export function IncomeStreamForm({ incomeStream, onSave, onCancel }: IncomeStreamFormProps) {
   const [formData, setFormData] = useState<Omit<IncomeStream, 'id'>>(() => {
     if (incomeStream) {
@@ -157,6 +164,9 @@ export function IncomeStreamForm({ incomeStream, onSave, onCancel }: IncomeStrea
             </option>
           ))}
         </select>
+        <p className="text-gray-500 dark:text-gray-400 text-xs mt-1">
+          {TAX_TREATMENT_DESCRIPTIONS[formData.taxTreatment]}
+        </p>
       </div>
 
       <div className="flex justify-end gap-3 pt-4">

--- a/src/components/IncomeStreamList.tsx
+++ b/src/components/IncomeStreamList.tsx
@@ -1,16 +1,12 @@
 import { useState } from 'react';
-import { Account, Profile, getAccountTypeLabel, getTaxTreatment } from '../types';
-import { AccountForm } from './AccountForm';
+import { IncomeStream, getIncomeTaxTreatmentLabel } from '../types';
+import { IncomeStreamForm } from './IncomeStreamForm';
 import { CHART_COLORS } from '../utils/constants';
-import { getDefaultWithdrawalAge } from '../utils/withdrawalDefaults';
-import type { CountryConfig } from '../countries';
 
-interface AccountListProps {
-  accounts: Account[];
-  profile: Profile;
-  countryConfig: CountryConfig;
-  onAdd: (account: Account) => void;
-  onUpdate: (account: Account) => void;
+interface IncomeStreamListProps {
+  incomeStreams: IncomeStream[];
+  onAdd: (stream: IncomeStream) => void;
+  onUpdate: (stream: IncomeStream) => void;
   onDelete: (id: string) => void;
 }
 
@@ -22,49 +18,53 @@ function formatCurrency(value: number): string {
   }).format(value);
 }
 
-function getTaxTreatmentColor(type: Account['type']): string {
-  const treatment = getTaxTreatment(type);
-  return CHART_COLORS[treatment];
+function getTaxTreatmentColor(treatment: IncomeStream['taxTreatment']): string {
+  switch (treatment) {
+    case 'social_security': return CHART_COLORS.socialSecurity;
+    case 'fully_taxable': return CHART_COLORS.pension;
+    case 'other_income': return CHART_COLORS.otherIncome;
+    case 'tax_free': return CHART_COLORS.taxFreeIncome;
+  }
 }
 
-export function AccountList({ accounts, profile, countryConfig, onAdd, onUpdate, onDelete }: AccountListProps) {
+export function IncomeStreamList({ incomeStreams, onAdd, onUpdate, onDelete }: IncomeStreamListProps) {
   const [showForm, setShowForm] = useState(false);
-  const [editingAccount, setEditingAccount] = useState<Account | undefined>();
+  const [editingStream, setEditingStream] = useState<IncomeStream | undefined>();
 
-  const handleSave = (account: Account) => {
-    if (editingAccount) {
-      onUpdate(account);
+  const handleSave = (stream: IncomeStream) => {
+    if (editingStream) {
+      onUpdate(stream);
     } else {
-      onAdd(account);
+      onAdd(stream);
     }
     setShowForm(false);
-    setEditingAccount(undefined);
+    setEditingStream(undefined);
   };
 
-  const handleEdit = (account: Account) => {
-    setEditingAccount(account);
+  const handleEdit = (stream: IncomeStream) => {
+    setEditingStream(stream);
     setShowForm(true);
   };
 
   const handleCancel = () => {
     setShowForm(false);
-    setEditingAccount(undefined);
+    setEditingStream(undefined);
   };
 
-  const totalBalance = accounts.reduce((sum, acc) => sum + acc.balance, 0);
+  const totalMonthly = incomeStreams.reduce((sum, s) => sum + s.monthlyAmount, 0);
 
   return (
     <div className="space-y-4">
       <div className="flex justify-between items-center border-b border-gray-200 dark:border-gray-600 pb-2">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-          Investment Accounts
+          Income Streams
         </h3>
         {!showForm && (
           <button
             onClick={() => setShowForm(true)}
             className="px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700"
           >
-            + Add Account
+            + Add Stream
           </button>
         )}
       </div>
@@ -72,38 +72,37 @@ export function AccountList({ accounts, profile, countryConfig, onAdd, onUpdate,
       {showForm && (
         <div className="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg">
           <h4 className="text-md font-medium text-gray-800 dark:text-gray-200 mb-3">
-            {editingAccount ? 'Edit Account' : 'New Account'}
+            {editingStream ? 'Edit Income Stream' : 'New Income Stream'}
           </h4>
-          <AccountForm
-            key={editingAccount?.id ?? 'new'}
-            account={editingAccount}
-            profile={profile}
+          <IncomeStreamForm
+            key={editingStream?.id ?? 'new'}
+            incomeStream={editingStream}
             onSave={handleSave}
             onCancel={handleCancel}
           />
         </div>
       )}
 
-      {accounts.length === 0 && !showForm ? (
+      {incomeStreams.length === 0 && !showForm ? (
         <p className="text-gray-500 dark:text-gray-400 text-sm py-4 text-center">
-          No accounts added yet. Click "Add Account" to get started.
+          No income streams added yet. Click "Add Stream" to add Social Security, pensions, or other retirement income.
         </p>
       ) : (
         <div className="space-y-2">
-          {accounts.map(account => (
+          {incomeStreams.map(stream => (
             <div
-              key={account.id}
+              key={stream.id}
               className="flex items-center justify-between p-3 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg hover:shadow-sm transition-shadow"
             >
               <div className="flex items-center gap-3">
                 <div
                   className="w-3 h-3 rounded-full"
-                  style={{ backgroundColor: getTaxTreatmentColor(account.type) }}
+                  style={{ backgroundColor: getTaxTreatmentColor(stream.taxTreatment) }}
                 />
                 <div>
-                  <div className="font-medium text-gray-900 dark:text-white">{account.name}</div>
+                  <div className="font-medium text-gray-900 dark:text-white">{stream.name}</div>
                   <div className="text-sm text-gray-500 dark:text-gray-400">
-                    {getAccountTypeLabel(account.type)} <br />Age {account.withdrawalRules?.startAge ?? getDefaultWithdrawalAge(account, profile.retirementAge, countryConfig)}+
+                    {getIncomeTaxTreatmentLabel(stream.taxTreatment)} <br />Age {stream.startAge}{stream.endAge ? `–${stream.endAge}` : '+'}
                   </div>
                 </div>
               </div>
@@ -111,16 +110,16 @@ export function AccountList({ accounts, profile, countryConfig, onAdd, onUpdate,
               <div className="flex items-center gap-4">
                 <div className="text-right">
                   <div className="font-medium text-gray-900 dark:text-white">
-                    {formatCurrency(account.balance)}
+                    {formatCurrency(stream.monthlyAmount)}/mo
                   </div>
                   <div className="text-sm text-gray-500 dark:text-gray-400">
-                    +{formatCurrency(account.annualContribution)}/yr
+                    {formatCurrency(stream.monthlyAmount * 12)}/yr
                   </div>
                 </div>
 
                 <div className="flex gap-1">
                   <button
-                    onClick={() => handleEdit(account)}
+                    onClick={() => handleEdit(stream)}
                     className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded"
                     title="Edit"
                   >
@@ -129,7 +128,7 @@ export function AccountList({ accounts, profile, countryConfig, onAdd, onUpdate,
                     </svg>
                   </button>
                   <button
-                    onClick={() => onDelete(account.id)}
+                    onClick={() => onDelete(stream.id)}
                     className="p-1.5 text-gray-500 dark:text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 rounded"
                     title="Delete"
                   >
@@ -142,10 +141,12 @@ export function AccountList({ accounts, profile, countryConfig, onAdd, onUpdate,
             </div>
           ))}
 
-          {accounts.length > 0 && (
+          {incomeStreams.length > 0 && (
             <div className="flex justify-between items-center pt-2 border-t border-gray-200 dark:border-gray-600 mt-2">
               <span className="font-medium text-gray-700 dark:text-gray-300">Total</span>
-              <span className="font-semibold text-gray-900 dark:text-white">{formatCurrency(totalBalance)}</span>
+              <span className="font-semibold text-gray-900 dark:text-white">
+                {formatCurrency(totalMonthly)}/mo ({formatCurrency(totalMonthly * 12)}/yr)
+              </span>
             </div>
           )}
         </div>

--- a/src/components/MethodologyPanel.tsx
+++ b/src/components/MethodologyPanel.tsx
@@ -573,7 +573,7 @@ export function MethodologyPanel({ profile, assumptions }: MethodologyPanelProps
       {/* Government Benefits */}
       <section className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
         <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-          {isCanada ? 'Government Benefits (CPP & OAS)' : 'Social Security Benefits'}
+          {isCanada ? 'Government Benefits (CPP & OAS)' : 'Retirement Income Streams'}
         </h3>
         <div className="space-y-4 text-sm">
           {isCanada ? (
@@ -601,13 +601,14 @@ export function MethodologyPanel({ profile, assumptions }: MethodologyPanelProps
             </>
           ) : (
             <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-4">
-              <h4 className="font-medium text-gray-800 dark:text-gray-200 mb-2">Social Security</h4>
+              <h4 className="font-medium text-gray-800 dark:text-gray-200 mb-2">Income Streams</h4>
               <ul className="space-y-1 text-gray-600 dark:text-gray-400">
-                <li>• Your benefit: {formatCurrency(profile.socialSecurityBenefit || 0)}/year (in today's dollars)</li>
-                <li>• Start age: {profile.socialSecurityStartAge || 67}</li>
+                <li>• Configure Social Security, pensions, and other retirement income in the Income Streams panel</li>
+                <li>• Each stream has a name, monthly benefit, start age, and tax treatment</li>
                 <li>• Benefits are inflation-adjusted annually</li>
-                <li>• Up to 85% of benefits are taxable depending on income</li>
-                <li>• Calculator assumes 85% taxable (maximum rate)</li>
+                <li>• Social Security streams: 85% taxable (maximum rate)</li>
+                <li>• Pension streams: 100% taxable as ordinary income</li>
+                <li>• Tax-free streams (e.g., VA disability): excluded from taxable income</li>
               </ul>
             </div>
           )}

--- a/src/components/ProfileForm.tsx
+++ b/src/components/ProfileForm.tsx
@@ -129,43 +129,44 @@ export function ProfileForm({ profile, onChange }: ProfileFormProps) {
         )}
       </div>
 
-      <h4 className="text-md font-medium text-gray-800 dark:text-gray-200 mt-6 mb-3">
-        {country === 'CA' ? 'CPP (Canada Pension Plan)' : 'Social Security'}
-      </h4>
+      {country === 'CA' && (
+        <>
+          <h4 className="text-md font-medium text-gray-800 dark:text-gray-200 mt-6 mb-3">
+            CPP (Canada Pension Plan)
+          </h4>
 
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-            Annual Benefit (today's $)
-            <Tooltip text={country === 'CA'
-              ? "Your estimated annual CPP benefit in today's dollars"
-              : "Your estimated annual Social Security benefit in today's dollars"}
-            />
-          </label>
-          <NumberInput
-            value={profile.socialSecurityBenefit || 0}
-            onChange={(val) => handleChange('socialSecurityBenefit', val)}
-            min={0}
-            placeholder="0"
-            defaultValue={0}
-            className={inputClassName}
-          />
-        </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Annual Benefit (today's $)
+                <Tooltip text="Your estimated annual CPP benefit in today's dollars" />
+              </label>
+              <NumberInput
+                value={profile.socialSecurityBenefit || 0}
+                onChange={(val) => handleChange('socialSecurityBenefit', val)}
+                min={0}
+                placeholder="0"
+                defaultValue={0}
+                className={inputClassName}
+              />
+            </div>
 
-        <div>
-          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-            Start Age
-          </label>
-          <NumberInput
-            value={profile.socialSecurityStartAge || (country === 'CA' ? 65 : 67)}
-            onChange={(val) => handleChange('socialSecurityStartAge', val)}
-            min={country === 'CA' ? 60 : 62}
-            max={70}
-            defaultValue={country === 'CA' ? 65 : 67}
-            className={inputClassName}
-          />
-        </div>
-      </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Start Age
+              </label>
+              <NumberInput
+                value={profile.socialSecurityStartAge || 65}
+                onChange={(val) => handleChange('socialSecurityStartAge', val)}
+                min={60}
+                max={70}
+                defaultValue={65}
+                className={inputClassName}
+              />
+            </div>
+          </div>
+        </>
+      )}
 
       {/* OAS Section - Canada Only */}
       {country === 'CA' && (

--- a/src/countries/usa/index.ts
+++ b/src/countries/usa/index.ts
@@ -137,8 +137,6 @@ export const USConfig: CountryConfig = {
     lifeExpectancy: 90,
     filingStatus: 'married_filing_jointly' as const,
     stateTaxRate: 0.05,
-    socialSecurityBenefit: 30000,
-    socialSecurityStartAge: 67,
   }),
 
   getContributionLimits: (): ContributionLimits => ({

--- a/src/hooks/useRetirementCalc.ts
+++ b/src/hooks/useRetirementCalc.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Account, Profile, Assumptions, AccumulationResult, RetirementResult } from '../types';
+import { Account, Profile, Assumptions, AccumulationResult, RetirementResult, IncomeStream } from '../types';
 import { calculateAccumulation } from '../utils/projections';
 import { calculateWithdrawals } from '../utils/withdrawals';
 import type { CountryConfig } from '../countries';
@@ -13,7 +13,8 @@ export function useRetirementCalc(
   accounts: Account[],
   profile: Profile,
   assumptions: Assumptions,
-  countryConfig: CountryConfig
+  countryConfig: CountryConfig,
+  incomeStreams: IncomeStream[]
 ): UseRetirementCalcResult {
   const accumulation = useMemo(() => {
     if (accounts.length === 0) {
@@ -38,8 +39,8 @@ export function useRetirementCalc(
         accountDepletionAges: {},
       };
     }
-    return calculateWithdrawals(accounts, profile, assumptions, accumulation, countryConfig);
-  }, [accounts, profile, assumptions, accumulation, countryConfig]);
+    return calculateWithdrawals(accounts, profile, assumptions, accumulation, countryConfig, incomeStreams);
+  }, [accounts, profile, assumptions, accumulation, countryConfig, incomeStreams]);
 
   return { accumulation, retirement };
 }

--- a/src/tests/calculations.test.ts
+++ b/src/tests/calculations.test.ts
@@ -7,6 +7,7 @@
 
 import { calculateAccumulation } from '../utils/projections';
 import { calculateWithdrawals } from '../utils/withdrawals';
+import { calculateIncomeStreamBenefits } from '../utils/incomeStreams';
 import {
   calculateFederalIncomeTax,
   calculateTotalFederalTax,
@@ -15,7 +16,7 @@ import {
   getStandardDeduction,
 } from '../utils/taxes';
 import { getRMDDivisor } from '../utils/constants';
-import { Account, Profile, Assumptions } from '../types';
+import { Account, Profile, Assumptions, IncomeStream } from '../types';
 import { getCountryConfig } from '../countries';
 import { getDefaultWithdrawalAge, getMaxWithdrawalAge } from '../utils/withdrawalDefaults';
 
@@ -398,8 +399,8 @@ function testWithdrawalPhase(): void {
   assert(age67 !== undefined, 'Has data for age 67');
 
   if (age65 && age67) {
-    assertApprox(age65.socialSecurityIncome, 0, 0.01, 'No SS income at age 65');
-    assertApprox(age67.socialSecurityIncome, 30000, 0.01, 'SS income at age 67 = $30,000');
+    assertApprox(age65.governmentBenefitIncome, 0, 0.01, 'No SS income at age 65');
+    assertApprox(age67.governmentBenefitIncome, 30000, 0.01, 'SS income at age 67 = $30,000');
 
     // Total withdrawal should decrease when SS starts
     assert(
@@ -507,7 +508,7 @@ function testIncomeContinuity(): void {
       const row = [
         year.age.toString().padStart(3),
         `$${(year.targetSpending / 1000).toFixed(1)}k`.padStart(8),
-        `$${(year.socialSecurityIncome / 1000).toFixed(1)}k`.padStart(8),
+        `$${(year.governmentBenefitIncome / 1000).toFixed(1)}k`.padStart(8),
         `$${(year.totalWithdrawal / 1000).toFixed(1)}k`.padStart(10),
         `$${(year.grossIncome / 1000).toFixed(1)}k`.padStart(8),
         `$${(year.totalTax / 1000).toFixed(1)}k`.padStart(8),
@@ -1098,7 +1099,7 @@ function testInflationConsistency(): void {
 
   if (age67) {
     const expectedSS = 30000 * Math.pow(1.03, 7);
-    assertApprox(age67.socialSecurityIncome, expectedSS, 1, 'SS inflated from current age to start age');
+    assertApprox(age67.governmentBenefitIncome, expectedSS, 1, 'SS inflated from current age to start age');
   }
 }
 
@@ -1617,6 +1618,223 @@ function testWithdrawalDefaults(): void {
 }
 
 // =============================================================================
+// INCOME STREAM CALCULATOR TESTS
+// =============================================================================
+
+function testIncomeStreamCalculator(): void {
+  section('INCOME STREAM CALCULATOR');
+
+  console.log('\n--- No streams ---');
+  const emptyResult = calculateIncomeStreamBenefits([], 67);
+  assertApprox(emptyResult.totalIncome, 0, 0.01, 'No streams = $0 income');
+
+  console.log('\n--- Single SS stream at start age ---');
+  const ssStream: IncomeStream = {
+    id: 'ss1',
+    name: 'Social Security',
+    monthlyAmount: 2500,
+    startAge: 67,
+    taxTreatment: 'social_security',
+  };
+  const ssResult = calculateIncomeStreamBenefits([ssStream], 67);
+  assertApprox(ssResult.totalIncome, 30000, 0.01, '$2500/mo = $30,000/yr at start age');
+  assertApprox(ssResult.byTaxTreatment.social_security, 30000, 0.01, 'All in social_security bucket');
+  assertApprox(ssResult.byTaxTreatment.fully_taxable, 0, 0.01, 'Nothing in fully_taxable');
+  assertApprox(ssResult.byTaxTreatment.other_income, 0, 0.01, 'Nothing in other_income');
+  assertApprox(ssResult.byTaxTreatment.tax_free, 0, 0.01, 'Nothing in tax_free');
+
+  console.log('\n--- Before start age ---');
+  const beforeResult = calculateIncomeStreamBenefits([ssStream], 65);
+  assertApprox(beforeResult.totalIncome, 0, 0.01, 'No income before start age');
+
+  console.log('\n--- Multiple streams with different start ages ---');
+  const streams: IncomeStream[] = [
+    { id: 'ss1', name: "Josh's SS", monthlyAmount: 2500, startAge: 67, taxTreatment: 'social_security' },
+    { id: 'ss2', name: "Spouse's SS", monthlyAmount: 2000, startAge: 70, taxTreatment: 'social_security' },
+    { id: 'pension1', name: "Spouse's NC Pension", monthlyAmount: 3000, startAge: 65, taxTreatment: 'fully_taxable' },
+  ];
+
+  const at65 = calculateIncomeStreamBenefits(streams, 65);
+  assertApprox(at65.totalIncome, 36000, 0.01, 'Age 65: only pension ($3000/mo)');
+  assertApprox(at65.byTaxTreatment.fully_taxable, 36000, 0.01, 'Pension in fully_taxable');
+  assertApprox(at65.byTaxTreatment.social_security, 0, 0.01, 'No SS yet');
+
+  const at67 = calculateIncomeStreamBenefits(streams, 67);
+  assertApprox(at67.totalIncome, 66000, 0.01, 'Age 67: pension + one SS');
+  assertApprox(at67.byTaxTreatment.social_security, 30000, 0.01, "Josh's SS active");
+
+  const at70 = calculateIncomeStreamBenefits(streams, 70);
+  assertApprox(at70.totalIncome, 90000, 0.01, 'Age 70: all streams active');
+  assertApprox(at70.byTaxTreatment.social_security, 54000, 0.01, 'Both SS streams');
+
+  console.log('\n--- Tax-free stream ---');
+  const vaDisability: IncomeStream = {
+    id: 'va1', name: 'VA Disability', monthlyAmount: 1500, startAge: 60, taxTreatment: 'tax_free',
+  };
+  const vaResult = calculateIncomeStreamBenefits([vaDisability], 65);
+  assertApprox(vaResult.totalIncome, 18000, 0.01, 'VA disability income');
+  assertApprox(vaResult.byTaxTreatment.tax_free, 18000, 0.01, 'All in tax_free bucket');
+
+  console.log('\n--- End age: income stops after endAge ---');
+  const tempJob: IncomeStream = {
+    id: 'job1', name: 'Part-time Work', monthlyAmount: 3000, startAge: 52, endAge: 62, taxTreatment: 'other_income',
+  };
+  const atAge55 = calculateIncomeStreamBenefits([tempJob], 55);
+  assertApprox(atAge55.totalIncome, 36000, 0.01, 'Active at age 55: $3000/mo = $36k/yr');
+  assertApprox(atAge55.byTaxTreatment.other_income, 36000, 0.01, 'All in other_income bucket');
+
+  const atAge62 = calculateIncomeStreamBenefits([tempJob], 62);
+  assertApprox(atAge62.totalIncome, 36000, 0.01, 'Still active at endAge 62 (inclusive)');
+
+  const atAge63 = calculateIncomeStreamBenefits([tempJob], 63);
+  assertApprox(atAge63.totalIncome, 0, 0.01, 'No income after endAge');
+
+  const atAge51 = calculateIncomeStreamBenefits([tempJob], 51);
+  assertApprox(atAge51.totalIncome, 0, 0.01, 'No income before startAge');
+
+  console.log('\n--- End age with mixed streams ---');
+  const mixedStreams: IncomeStream[] = [
+    { id: 'job1', name: 'Part-time', monthlyAmount: 2000, startAge: 52, endAge: 60, taxTreatment: 'other_income' },
+    { id: 'ss1', name: 'Social Security', monthlyAmount: 2500, startAge: 67, taxTreatment: 'social_security' },
+  ];
+  const mixedAt55 = calculateIncomeStreamBenefits(mixedStreams, 55);
+  assertApprox(mixedAt55.totalIncome, 24000, 0.01, 'Age 55: only part-time job');
+  const mixedAt65 = calculateIncomeStreamBenefits(mixedStreams, 65);
+  assertApprox(mixedAt65.totalIncome, 0, 0.01, 'Age 65: job ended, SS not started');
+  const mixedAt67 = calculateIncomeStreamBenefits(mixedStreams, 67);
+  assertApprox(mixedAt67.totalIncome, 30000, 0.01, 'Age 67: only SS');
+
+  console.log('\n--- other_income tax treatment ---');
+  const otherStream: IncomeStream = {
+    id: 'other1', name: 'Consulting', monthlyAmount: 5000, startAge: 60, taxTreatment: 'other_income',
+  };
+  const otherResult = calculateIncomeStreamBenefits([otherStream], 65);
+  assertApprox(otherResult.totalIncome, 60000, 0.01, 'Other income: $5000/mo = $60k/yr');
+  assertApprox(otherResult.byTaxTreatment.other_income, 60000, 0.01, 'All in other_income bucket');
+  assertApprox(otherResult.byTaxTreatment.fully_taxable, 0, 0.01, 'Nothing in fully_taxable');
+  assertApprox(otherResult.byTaxTreatment.social_security, 0, 0.01, 'Nothing in social_security');
+}
+
+// =============================================================================
+// INCOME STREAM WITHDRAWAL INTEGRATION TESTS
+// =============================================================================
+
+function testIncomeStreamWithdrawals(): void {
+  section('INCOME STREAM WITHDRAWAL INTEGRATION');
+
+  const account: Account = {
+    id: 'test',
+    name: 'Traditional 401k',
+    type: 'traditional_401k',
+    balance: 1000000,
+    annualContribution: 0,
+    contributionGrowthRate: 0,
+    returnRate: 0,
+  };
+
+  const profileNoSS: Profile = {
+    currentAge: 65,
+    retirementAge: 65,
+    lifeExpectancy: 68,
+    filingStatus: 'married_filing_jointly',
+    stateTaxRate: 0.05,
+    // No socialSecurityBenefit — it's in income streams now
+  };
+
+  const assumptions: Assumptions = {
+    inflationRate: 0,  // No inflation for simpler testing
+    safeWithdrawalRate: 0.04,
+    retirementReturnRate: 0,
+  };
+
+  console.log('\n--- Income Streams Reduce Withdrawal Need ---');
+
+  const ssStreams: IncomeStream[] = [
+    {
+      id: 'ss1',
+      name: 'Social Security',
+      monthlyAmount: 2500, // $30k/year
+      startAge: 67,
+      taxTreatment: 'social_security',
+    },
+  ];
+
+  const accum = calculateAccumulation([account], profileNoSS, usConfig);
+  const resultWithSS = calculateWithdrawals([account], profileNoSS, assumptions, accum, usConfig, ssStreams);
+
+  const is65 = resultWithSS.yearlyWithdrawals.find(y => y.age === 65);
+  const is67 = resultWithSS.yearlyWithdrawals.find(y => y.age === 67);
+
+  assert(is65 !== undefined, 'Has data for age 65');
+  assert(is67 !== undefined, 'Has data for age 67');
+
+  if (is65 && is67) {
+    assertApprox(is65.incomeStreamIncome, 0, 0.01, 'No income stream income at age 65');
+    assert(is67.incomeStreamIncome > 0, 'Income stream income at age 67 > $0');
+    assert(
+      is67.totalWithdrawal < is65.totalWithdrawal,
+      `Withdrawal decreases when income streams start ($${is67.totalWithdrawal.toFixed(0)} < $${is65.totalWithdrawal.toFixed(0)})`
+    );
+  }
+
+  console.log('\n--- Multiple Income Streams (SS + Pension) ---');
+
+  const multiStreams: IncomeStream[] = [
+    { id: 'ss1', name: 'Social Security', monthlyAmount: 2500, startAge: 67, taxTreatment: 'social_security' },
+    { id: 'pension1', name: 'State Pension', monthlyAmount: 3000, startAge: 65, taxTreatment: 'fully_taxable' },
+  ];
+
+  const resultMulti = calculateWithdrawals([account], profileNoSS, assumptions, accum, usConfig, multiStreams);
+
+  const multi65 = resultMulti.yearlyWithdrawals.find(y => y.age === 65);
+  const multi67 = resultMulti.yearlyWithdrawals.find(y => y.age === 67);
+
+  if (multi65 && multi67) {
+    assert(multi65.incomeStreamIncome > 0, 'Pension income at age 65');
+    assert(
+      multi67.incomeStreamIncome > multi65.incomeStreamIncome,
+      'More income at 67 when SS kicks in'
+    );
+    assert(
+      multi67.totalWithdrawal < multi65.totalWithdrawal,
+      'Less portfolio withdrawal needed at 67'
+    );
+  }
+
+  console.log('\n--- Tax-Free Income Stream ---');
+
+  const taxFreeStreams: IncomeStream[] = [
+    { id: 'va1', name: 'VA Disability', monthlyAmount: 2000, startAge: 65, taxTreatment: 'tax_free' },
+  ];
+
+  const resultTaxFree = calculateWithdrawals([account], profileNoSS, assumptions, accum, usConfig, taxFreeStreams);
+  const resultNone = calculateWithdrawals([account], profileNoSS, assumptions, accum, usConfig, []);
+
+  const tf65 = resultTaxFree.yearlyWithdrawals.find(y => y.age === 65);
+  const none65 = resultNone.yearlyWithdrawals.find(y => y.age === 65);
+
+  if (tf65 && none65) {
+    assert(tf65.incomeStreamIncome > 0, 'Tax-free income counted in income streams');
+    assert(
+      tf65.totalWithdrawal < none65.totalWithdrawal,
+      'Tax-free income reduces withdrawal need'
+    );
+    assert(
+      tf65.federalTax <= none65.federalTax + 1,
+      'Tax-free income does not increase federal tax'
+    );
+  }
+
+  console.log('\n--- No Income Streams (empty array) ---');
+
+  const resultEmpty = calculateWithdrawals([account], profileNoSS, assumptions, accum, usConfig, []);
+  const empty65 = resultEmpty.yearlyWithdrawals.find(y => y.age === 65);
+  if (empty65) {
+    assertApprox(empty65.incomeStreamIncome, 0, 0.01, 'Empty streams = $0 income stream income');
+  }
+}
+
+// =============================================================================
 // RUN ALL TESTS
 // =============================================================================
 
@@ -1641,6 +1859,8 @@ function runAllTests(): void {
   testWithdrawalWithConfigurableAge();
   testWithdrawalDefaults();
   testEarlyWithdrawalPenalties();
+  testIncomeStreamCalculator();
+  testIncomeStreamWithdrawals();
 
   console.log('\n' + '='.repeat(60));
   console.log('TEST SUMMARY');

--- a/src/tests/calculations.test.ts
+++ b/src/tests/calculations.test.ts
@@ -1832,6 +1832,39 @@ function testIncomeStreamWithdrawals(): void {
   if (empty65) {
     assertApprox(empty65.incomeStreamIncome, 0, 0.01, 'Empty streams = $0 income stream income');
   }
+
+  console.log('\n--- Income Stream with endAge stops after endAge ---');
+
+  const endAgeStreams: IncomeStream[] = [
+    { id: 'job1', name: 'Part-time Work', monthlyAmount: 2000, startAge: 65, endAge: 66, taxTreatment: 'other_income' },
+  ];
+
+  const profileEndAge: Profile = {
+    currentAge: 65,
+    retirementAge: 65,
+    lifeExpectancy: 70,
+    filingStatus: 'married_filing_jointly',
+    stateTaxRate: 0.05,
+  };
+
+  const accumEndAge = calculateAccumulation([account], profileEndAge, usConfig);
+  const resultEndAge = calculateWithdrawals([account], profileEndAge, assumptions, accumEndAge, usConfig, endAgeStreams);
+
+  const ea65 = resultEndAge.yearlyWithdrawals.find(y => y.age === 65);
+  const ea66 = resultEndAge.yearlyWithdrawals.find(y => y.age === 66);
+  const ea67 = resultEndAge.yearlyWithdrawals.find(y => y.age === 67);
+
+  assert(ea65 !== undefined && ea66 !== undefined && ea67 !== undefined, 'Has data for ages 65-67');
+
+  if (ea65 && ea66 && ea67) {
+    assert(ea65.incomeStreamIncome > 0, 'Income stream active at age 65');
+    assert(ea66.incomeStreamIncome > 0, 'Income stream active at endAge 66 (inclusive)');
+    assertApprox(ea67.incomeStreamIncome, 0, 0.01, 'Income stream stopped after endAge');
+    assert(
+      ea67.totalWithdrawal > ea65.totalWithdrawal,
+      `Withdrawal increases after stream ends ($${ea67.totalWithdrawal.toFixed(0)} > $${ea65.totalWithdrawal.toFixed(0)})`
+    );
+  }
 }
 
 // =============================================================================

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -71,8 +71,8 @@ export interface Profile {
   filingStatus?: FilingStatus; // US only
   stateTaxRate?: number; // US only (as decimal), CA uses province
   annualIncome?: number; // For CA RRSP contribution room calculation
-  socialSecurityBenefit?: number; // CPP for CA, Social Security for US (annual)
-  socialSecurityStartAge?: number; // CPP/SS start age
+  socialSecurityBenefit?: number; // Canada CPP only; US uses income streams (annual)
+  socialSecurityStartAge?: number; // Canada CPP start age; US uses income streams
   secondaryBenefitStartAge?: number; // OAS for CA
   secondaryBenefitAmount?: number; // OAS amount for CA
 }
@@ -227,7 +227,7 @@ export function getIncomeTaxTreatmentLabel(treatment: IncomeTaxTreatment): strin
     case 'social_security':
       return 'Social Security';
     case 'fully_taxable':
-      return 'Pension';
+      return 'Pension / Annuity';
     case 'other_income':
       return 'Other Income';
     case 'tax_free':

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,17 @@ export type FilingStatus = 'single' | 'married_filing_jointly';
 
 export type TaxTreatment = 'pretax' | 'roth' | 'taxable' | 'hsa';
 
+export type IncomeTaxTreatment = 'social_security' | 'fully_taxable' | 'other_income' | 'tax_free';
+
+export interface IncomeStream {
+  id: string;
+  name: string;
+  monthlyAmount: number;      // in today's dollars
+  startAge: number;
+  endAge?: number;            // optional: last age income is received
+  taxTreatment: IncomeTaxTreatment;
+}
+
 export interface AccountWithdrawalRules {
   startAge: number;  // Age when withdrawals can begin
 }
@@ -93,7 +104,8 @@ export interface YearlyWithdrawal {
   withdrawals: Record<string, number>; // accountId -> withdrawal
   remainingBalances: Record<string, number>; // accountId -> remaining balance
   totalWithdrawal: number;
-  socialSecurityIncome: number;
+  governmentBenefitIncome: number;  // was socialSecurityIncome — Canada CPP/OAS only
+  incomeStreamIncome: number;       // user-defined income streams (SS, pensions, etc.)
   grossIncome: number;
   federalTax: number;
   stateTax: number;
@@ -208,4 +220,17 @@ export function is401k(type: AccountType): boolean {
 
 export function isTraditional(type: string): boolean {
   return type === 'traditional_401k' || type === 'traditional_ira';
+}
+
+export function getIncomeTaxTreatmentLabel(treatment: IncomeTaxTreatment): string {
+  switch (treatment) {
+    case 'social_security':
+      return 'Social Security';
+    case 'fully_taxable':
+      return 'Pension';
+    case 'other_income':
+      return 'Other Income';
+    case 'tax_free':
+      return 'Tax-Free';
+  }
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,6 @@
 import { TaxBracket, RMDEntry } from '../types';
+import type { IncomeStream } from '../types';
+import { v4 as uuidv4 } from 'uuid';
 
 // 2024 Federal Tax Brackets - Married Filing Jointly
 export const TAX_BRACKETS_MFJ: TaxBracket[] = [
@@ -112,6 +114,10 @@ export const CHART_COLORS = {
   tax: '#ef4444', // red
   socialSecurity: '#6366f1', // indigo
   spending: '#0d9488', // teal
+  pension: '#ec4899',          // pink
+  otherIncome: '#f97316',      // orange
+  taxFreeIncome: '#06b6d4',    // cyan
+  retirementIncome: '#0ea5e9', // sky
 };
 
 // Default values for new app state
@@ -123,8 +129,6 @@ export const DEFAULT_PROFILE = {
   region: 'CA', // California
   filingStatus: 'married_filing_jointly' as const,
   stateTaxRate: 0.05,
-  socialSecurityBenefit: 30000,
-  socialSecurityStartAge: 67,
 };
 
 export const DEFAULT_ASSUMPTIONS = {
@@ -132,3 +136,13 @@ export const DEFAULT_ASSUMPTIONS = {
   safeWithdrawalRate: 0.04,
   retirementReturnRate: 0.05,
 };
+
+export const DEFAULT_INCOME_STREAMS: IncomeStream[] = [
+  {
+    id: uuidv4(),
+    name: 'Social Security',
+    monthlyAmount: 2500,
+    startAge: 67,
+    taxTreatment: 'social_security',
+  },
+];

--- a/src/utils/incomeStreams.ts
+++ b/src/utils/incomeStreams.ts
@@ -1,0 +1,34 @@
+import type { IncomeStream, IncomeTaxTreatment } from '../types';
+
+export interface IncomeStreamResult {
+  totalIncome: number;
+  byTaxTreatment: Record<IncomeTaxTreatment, number>;
+}
+
+/**
+ * Calculate total income from income streams for a given age.
+ * Amounts are in today's dollars — caller applies inflation.
+ */
+export function calculateIncomeStreamBenefits(
+  incomeStreams: IncomeStream[],
+  age: number,
+): IncomeStreamResult {
+  const byTaxTreatment: Record<IncomeTaxTreatment, number> = {
+    social_security: 0,
+    fully_taxable: 0,
+    other_income: 0,
+    tax_free: 0,
+  };
+
+  let totalIncome = 0;
+
+  for (const stream of incomeStreams) {
+    if (age >= stream.startAge && (!stream.endAge || age <= stream.endAge)) {
+      const annualAmount = stream.monthlyAmount * 12;
+      totalIncome += annualAmount;
+      byTaxTreatment[stream.taxTreatment] += annualAmount;
+    }
+  }
+
+  return { totalIncome, byTaxTreatment };
+}

--- a/src/utils/withdrawals.ts
+++ b/src/utils/withdrawals.ts
@@ -8,6 +8,7 @@ import {
   getTaxTreatment,
   isTraditional,
 } from '../types';
+import type { IncomeStream } from '../types';
 import {
   calculateTotalFederalTax,
   calculateStateTax,
@@ -17,6 +18,7 @@ import { getRMDDivisor, RMD_START_AGE } from './constants';
 import type { CountryConfig } from '../countries';
 import { calculatePenalties, type AccountWithdrawal } from './penaltyCalculator';
 import { getDefaultWithdrawalAge } from './withdrawalDefaults';
+import { calculateIncomeStreamBenefits } from './incomeStreams';
 
 interface AccountState {
   id: string;
@@ -78,7 +80,8 @@ export function calculateWithdrawals(
   profile: Profile,
   assumptions: Assumptions,
   accumulationResult: AccumulationResult,
-  countryConfig?: CountryConfig
+  countryConfig?: CountryConfig,
+  incomeStreams?: IncomeStream[]
 ): RetirementResult {
   const retirementYears = profile.lifeExpectancy - profile.retirementAge;
   const currentYear = new Date().getFullYear();
@@ -139,7 +142,22 @@ export function calculateWithdrawals(
           Math.pow(1 + assumptions.inflationRate, yearsFromNow);
       }
     }
-    const socialSecurityIncome = governmentBenefits; // Keep variable name for compatibility
+    const governmentBenefitIncome = governmentBenefits;
+
+    // Calculate user-defined income stream benefits
+    const streamResult = calculateIncomeStreamBenefits(incomeStreams || [], age);
+    // Apply inflation adjustment (stream amounts are in today's dollars)
+    const yearsFromNow = age - profile.currentAge;
+    const inflationMultiplier = Math.pow(1 + assumptions.inflationRate, yearsFromNow);
+    const inflatedStreamIncome = streamResult.totalIncome * inflationMultiplier;
+    const inflatedStreamByTax = {
+      social_security: streamResult.byTaxTreatment.social_security * inflationMultiplier,
+      fully_taxable: streamResult.byTaxTreatment.fully_taxable * inflationMultiplier,
+      other_income: streamResult.byTaxTreatment.other_income * inflationMultiplier,
+      tax_free: streamResult.byTaxTreatment.tax_free * inflationMultiplier,
+    };
+
+    const totalRetirementIncome = governmentBenefitIncome + inflatedStreamIncome;
 
     // Calculate minimum required withdrawals (RMD/RRIF) for each traditional account
     // NOTE: Per IRS rules, RMDs are calculated per-account, not on total balance.
@@ -157,17 +175,25 @@ export function calculateWithdrawals(
       });
     const rmdAmount = totalMinimumWithdrawal;
 
+    // Pre-compute non-portfolio taxable income for bracket-filling logic
+    const nonPortfolioTaxableIncome =
+      governmentBenefitIncome * 0.85 +
+      inflatedStreamByTax.social_security * 0.85 +
+      inflatedStreamByTax.fully_taxable +
+      inflatedStreamByTax.other_income;
+
     // Tax-optimized withdrawal strategy
     const withdrawals = performTaxOptimizedWithdrawal(
       accountStates,
       accounts,  // NEW: pass full accounts array
       targetSpending,
       rmdAmount,
-      socialSecurityIncome,
+      totalRetirementIncome,
       profile,
       accountDepletionAges,
       age,
-      countryConfig
+      countryConfig,
+      nonPortfolioTaxableIncome
     );
 
     // Calculate early withdrawal penalties
@@ -182,7 +208,16 @@ export function calculateWithdrawals(
     });
 
     // Calculate taxes using country-specific logic
-    const ordinaryIncome = withdrawals.traditionalWithdrawal + socialSecurityIncome * 0.85; // 85% of SS/CPP taxable
+    // Government benefits (Canada CPP/OAS): 85% taxable
+    const governmentBenefitTaxable = governmentBenefitIncome * 0.85;
+    // Income streams: per-bucket tax rules
+    const ssStreamTaxable = inflatedStreamByTax.social_security * 0.85;
+    const pensionTaxable = inflatedStreamByTax.fully_taxable;
+    const otherIncomeTaxable = inflatedStreamByTax.other_income;
+    // tax_free: excluded from taxable income
+
+    const ordinaryIncome = withdrawals.traditionalWithdrawal +
+      governmentBenefitTaxable + ssStreamTaxable + pensionTaxable + otherIncomeTaxable;
     const capitalGains = withdrawals.taxableGains;
 
     let federalTax: number;
@@ -227,7 +262,7 @@ export function calculateWithdrawals(
     lifetimeTaxesPaid += totalTax;
 
     const grossWithdrawal = withdrawals.total;
-    const grossIncome = grossWithdrawal + socialSecurityIncome;
+    const grossIncome = grossWithdrawal + governmentBenefitIncome + inflatedStreamIncome;
     const afterTaxIncome = grossIncome - totalTax;
 
     // Record the year's data
@@ -242,7 +277,8 @@ export function calculateWithdrawals(
       withdrawals: withdrawals.byAccount,
       remainingBalances,
       totalWithdrawal: grossWithdrawal,
-      socialSecurityIncome,
+      governmentBenefitIncome,
+      incomeStreamIncome: inflatedStreamIncome,
       grossIncome,
       federalTax,
       stateTax,
@@ -296,11 +332,12 @@ function performTaxOptimizedWithdrawal(
   accounts: Account[],  // NEW: need full account objects
   targetSpending: number,
   rmdAmount: number,
-  socialSecurityIncome: number,
+  totalRetirementIncome: number,
   profile: Profile,
   accountDepletionAges: Record<string, number | null>,
   age: number,
-  countryConfig?: CountryConfig
+  countryConfig?: CountryConfig,
+  nonPortfolioTaxableIncome?: number
 ): WithdrawalResult {
   const result: WithdrawalResult = {
     total: 0,
@@ -330,8 +367,8 @@ function performTaxOptimizedWithdrawal(
     }
   };
 
-  // How much do we need after Social Security?
-  let remainingNeed = Math.max(0, targetSpending - socialSecurityIncome);
+  // How much do we need after all retirement income (government benefits + income streams)?
+  let remainingNeed = Math.max(0, targetSpending - totalRetirementIncome);
 
   // Filter to only available accounts
   const availableAccounts = getAvailableAccounts(
@@ -380,7 +417,8 @@ function performTaxOptimizedWithdrawal(
   const standardDeduction = getStandardDeduction(filingStatus);
   const bracket12Max = filingStatus === 'married_filing_jointly' ? 94300 : 47150;
   const targetOrdinaryIncome = standardDeduction + bracket12Max;
-  const currentOrdinaryIncome = result.traditionalWithdrawal + socialSecurityIncome * 0.85;
+  const currentOrdinaryIncome = result.traditionalWithdrawal +
+    (nonPortfolioTaxableIncome || 0);
   const roomIn12Bracket = Math.max(0, targetOrdinaryIncome - currentOrdinaryIncome);
 
   // Withdraw additional from traditional if we have room and need the money


### PR DESCRIPTION
### Summary
Replace the US Social Security profile fields with a unified Income Streams system that supports multiple retirement income sources — Social Security, pensions, part-time work, VA disability, and other fixed benefits.

Each stream has a name, monthly benefit, start age, optional end age, and tax treatment:
- Social Security (85% taxable)
- Pension (100% ordinary income)
- Other Income (100% ordinary income — displayed separately for part-time work, consulting, etc.)
- Tax-Free (excluded from taxable income)

Streams default to lifetime but can have an optional end age for temporary income (e.g., part-time work from age 52–62).

### Key changes:
- New IncomeStream type with optional endAge and calculator utility
- Four tax treatment categories: social_security, fully_taxable, other_income, tax_free
- Collapsible Income Streams panel in sidebar with add/edit/delete
- Withdrawal engine integrates streams with inflation adjustment and per-bucket tax handling (bracket-filling accounts for non-portfolio taxable income)
- Chart splits income into up to 4 stacked bands by tax treatment (Social Security, Pension, Other Income, Tax-Free)
- Data table adds Income Streams tab with per-stream breakdown and color-coded columns
- US ProfileForm hides SS fields (now managed via income streams)
- Canada CPP/OAS left untouched for upstream compatibility
- Default SS entry ($2,500/mo at age 67) for US users
- Account list now shows resolved withdrawal start age
- 161 tests passing including new income stream and end age tests

### Screenshots:
<img width="1235" height="944" alt="image" src="https://github.com/user-attachments/assets/0dc6f7d1-e37b-41bb-b796-7be4bb374b69" />
