### PR TITLE
Note that income stream amounts are in today's dollars

### DIFF
--- a/src/components/IncomeStreamForm.tsx
+++ b/src/components/IncomeStreamForm.tsx
@@ -104,7 +104,13 @@ export function IncomeStreamForm({ incomeStream, onSave, onCancel }: IncomeStrea
             defaultValue={0}
             className={errors.monthlyAmount ? inputErrorClassName : inputClassName}
           />
-          {errors.monthlyAmount && <p className="text-red-500 text-xs mt-1">{errors.monthlyAmount}</p>}
+          {errors.monthlyAmount ? (
+            <p className="text-red-500 text-xs mt-1">{errors.monthlyAmount}</p>
+          ) : (
+            <p className="text-gray-500 dark:text-gray-400 text-xs mt-1">
+              In today's dollars — automatically adjusted for inflation to your retirement years.
+            </p>
+          )}
         </div>
 
         <div>


### PR DESCRIPTION
## Summary
Income stream monthly benefits (including Social Security) are entered in **today's dollars** and inflated to retirement-year dollars by the withdrawal engine ([incomeStreams.ts](src/utils/incomeStreams.ts), [withdrawals.ts:150-151](src/utils/withdrawals.ts)). This wasn't clear in the UI.

This adds a helper note under the **Monthly Benefit** field in the income stream form:

> _In today's dollars — automatically adjusted for inflation to your retirement years._

The note sits where the validation error would otherwise appear and supports dark mode.

## Testing
- `npm run build` passes (TypeScript check + production build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)