### PR TITLE
Add export feature: scenario JSON, CSV, and print report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 npm run dev      # Start development server
 npm run build    # TypeScript check + production build
 npm run lint     # ESLint
-npm test         # Run calculation tests
+npm test         # Run calculation + export tests
 ```
 
 ## Architecture
@@ -50,6 +50,18 @@ This is a React retirement planning calculator that projects portfolio growth an
 - Defaults are smart: traditional accounts default to 60 (US) or retirement age (Canada)
 - Validation enforces RMD age constraints (can't delay past age 73 US, 71 Canada)
 - Early withdrawals trigger 10% penalty for US traditional accounts before age 59.5
+
+**Export (`src/utils/export/`):**
+
+Three export paths share one foundation. `tables.ts` turns results into presentation-neutral `ExportTable` objects (columns + rows + metadata); `csv.ts` serializes them for spreadsheets and `PrintReport.tsx` renders the same objects as HTML. Add a column once and both outputs get it.
+
+- **Scenario JSON** (`scenario.ts`): saves/loads all five localStorage keys plus `schemaVersion`. Import validates every field, drops unknown ones, then writes storage and reloads — the same approach country switching uses, so providers re-initialize cleanly. Bump `SCENARIO_SCHEMA_VERSION` on any breaking shape change.
+- **CSV**: one button per data-table view, exporting whatever view is active. Header row first (so spreadsheets auto-detect it), metadata after a trailing blank line, raw unformatted numbers, UTF-8 BOM, CRLF.
+- **Print report** (`PrintReport.tsx`): mounts off-screen at a fixed 720px (7.5in at 96dpi) because Recharts measures its container and cannot size an element with no layout. Charts must be passed `animate={false}` — Recharts reveals series by animating a clip path from zero width, so an animating chart prints blank. Dark mode is stripped for the duration and restored afterward.
+
+**Nominal vs. real dollars:**
+
+Everything the engine outputs is nominal (future) dollars. `presentValue`/`inflationFactor` in `export/realDollars.ts` are the single conversion point, used by both `SummaryCards` and the exports. Exports carry nominal as the primary columns, a Real column for headline figures, and an `Inflation Factor` column so any other column can be deflated in a spreadsheet. Note that tax brackets are not indexed to inflation in this model, so nominal tax figures include real bracket creep — deflating them gives the present value of dollars paid, not what an indexed-bracket world would charge.
 
 **Known Simplifications (Penalty Calculations):**
 - Roth contributions vs earnings not tracked separately. In reality, Roth contributions can be withdrawn penalty-free at any time; only earnings face the 10% penalty before age 59.5.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "tsx src/tests/calculations.test.ts",
+    "test": "tsx src/tests/calculations.test.ts && tsx src/tests/export.test.ts",
     "test:watch": "tsx watch src/tests/calculations.test.ts"
   },
   "dependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,14 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { Account, Profile, Assumptions, IncomeStream } from './types';
 import { DEFAULT_PROFILE, DEFAULT_ASSUMPTIONS, DEFAULT_INCOME_STREAMS } from './utils/constants';
+import { STORAGE_KEYS } from './utils/storageKeys';
+import {
+  buildScenario,
+  downloadJson,
+  parseScenario,
+  scenarioFilename,
+  type ScenarioFile,
+} from './utils/export';
 import { useRetirementCalc } from './hooks/useRetirementCalc';
 import { useLocalStorage, useDarkMode } from './hooks/useLocalStorage';
 import { CountryProvider, useCountry } from './contexts/CountryContext';
@@ -20,6 +28,7 @@ import { ChartComposition } from './components/ChartComposition';
 import { MethodologyPanel } from './components/MethodologyPanel';
 import { DataTableAccumulation } from './components/DataTableAccumulation';
 import { DataTableWithdrawal } from './components/DataTableWithdrawal';
+import { PrintReport } from './components/PrintReport';
 import { v4 as uuidv4 } from 'uuid';
 
 // Default accounts for US
@@ -192,6 +201,10 @@ function AppContent() {
   const [activeTab, setActiveTab] = useState<TabType>('summary');
   const [expandedSection, setExpandedSection] = useState<string | null>('accounts');
   const [showResetConfirm, setShowResetConfirm] = useState(false);
+  const [pendingImport, setPendingImport] = useState<ScenarioFile | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [isPrinting, setIsPrinting] = useState(false);
+  const printGeneratedAt = useRef(new Date());
 
   const { accumulation, retirement } = useRetirementCalc(accounts, profile, assumptions, countryConfig, incomeStreams);
 
@@ -245,6 +258,111 @@ function AppContent() {
     setShowResetConfirm(false);
   }, []);
 
+  // --- Save / load plan ---------------------------------------------------
+
+  const handleSavePlan = useCallback(() => {
+    const now = new Date();
+    const scenario = buildScenario(
+      {
+        country,
+        profile: { ...profile, country },
+        accounts,
+        incomeStreams,
+        assumptions,
+      },
+      now
+    );
+    downloadJson(scenarioFilename(now), JSON.stringify(scenario, null, 2));
+  }, [country, profile, accounts, incomeStreams, assumptions]);
+
+  const handleLoadPlanFile = useCallback(async (file: File) => {
+    let text: string;
+    try {
+      text = await file.text();
+    } catch {
+      setPendingImport(null);
+      setImportError('That file could not be read.');
+      return;
+    }
+
+    const result = parseScenario(text);
+    if (result.ok) {
+      setImportError(null);
+      setPendingImport(result.scenario);
+    } else {
+      setPendingImport(null);
+      setImportError(result.error);
+    }
+  }, []);
+
+  const confirmImport = useCallback(() => {
+    if (!pendingImport) return;
+
+    // Write the whole persisted state at once, then reload. This is the same
+    // approach country switching uses: it guarantees every provider and hook
+    // re-initializes from the new data (including account normalization and
+    // the country config) rather than trying to sync state in place.
+    localStorage.setItem(STORAGE_KEYS.country, pendingImport.country);
+    localStorage.setItem(STORAGE_KEYS.profile, JSON.stringify(pendingImport.profile));
+    localStorage.setItem(STORAGE_KEYS.accounts, JSON.stringify(pendingImport.accounts));
+    localStorage.setItem(
+      STORAGE_KEYS.incomeStreams,
+      JSON.stringify(pendingImport.incomeStreams)
+    );
+    localStorage.setItem(
+      STORAGE_KEYS.assumptions,
+      JSON.stringify(pendingImport.assumptions)
+    );
+
+    window.location.reload();
+  }, [pendingImport]);
+
+  const cancelImport = useCallback(() => {
+    setPendingImport(null);
+    setImportError(null);
+  }, []);
+
+  // --- Print report -------------------------------------------------------
+
+  const handlePrintReport = useCallback(() => {
+    printGeneratedAt.current = new Date();
+    setIsPrinting(true);
+  }, []);
+
+  // Mount the report, let Recharts measure and draw it, then open the print
+  // dialog. Dark mode is stripped for the duration so the report prints on
+  // white instead of burning a page of dark backgrounds.
+  useEffect(() => {
+    if (!isPrinting) return;
+
+    const root = document.documentElement;
+    const wasDark = root.classList.contains('dark');
+    const restoreDarkMode = () => {
+      if (wasDark) root.classList.add('dark');
+    };
+    if (wasDark) root.classList.remove('dark');
+
+    const timer = window.setTimeout(() => {
+      try {
+        window.print();
+      } finally {
+        restoreDarkMode();
+        setIsPrinting(false);
+      }
+    }, 400);
+
+    return () => {
+      window.clearTimeout(timer);
+      restoreDarkMode();
+    };
+  }, [isPrinting]);
+
+  const exportActions = {
+    onSavePlan: handleSavePlan,
+    onLoadPlanFile: handleLoadPlanFile,
+    onPrintReport: handlePrintReport,
+  };
+
   const tabs: { id: TabType; label: string }[] = [
     { id: 'summary', label: 'Summary' },
     { id: 'accumulation', label: 'Accumulation Phase' },
@@ -253,11 +371,103 @@ function AppContent() {
   ];
 
   return (
+    <>
     <Layout
       isDarkMode={isDarkMode}
       onToggleDarkMode={toggleDarkMode}
       onReset={handleReset}
+      exportActions={exportActions}
     >
+      {/* Import Confirmation Modal */}
+      {pendingImport && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 max-w-md mx-4">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+              Load this plan?
+            </h3>
+            <p className="text-gray-600 dark:text-gray-300 mb-3">
+              This will replace your current accounts, profile, income streams, and
+              assumptions. This action cannot be undone.
+            </p>
+            <dl className="text-sm bg-gray-50 dark:bg-gray-900 rounded-md p-3 mb-4 space-y-1">
+              <div className="flex justify-between gap-4">
+                <dt className="text-gray-500 dark:text-gray-400">Country</dt>
+                <dd className="text-gray-900 dark:text-white font-medium">
+                  {pendingImport.country === 'CA' ? 'Canada' : 'United States'}
+                  {pendingImport.country !== country && (
+                    <span className="text-amber-600 dark:text-amber-400"> (switching)</span>
+                  )}
+                </dd>
+              </div>
+              <div className="flex justify-between gap-4">
+                <dt className="text-gray-500 dark:text-gray-400">Accounts</dt>
+                <dd className="text-gray-900 dark:text-white font-medium">
+                  {pendingImport.accounts.length}
+                </dd>
+              </div>
+              <div className="flex justify-between gap-4">
+                <dt className="text-gray-500 dark:text-gray-400">Income streams</dt>
+                <dd className="text-gray-900 dark:text-white font-medium">
+                  {pendingImport.incomeStreams.length}
+                </dd>
+              </div>
+              <div className="flex justify-between gap-4">
+                <dt className="text-gray-500 dark:text-gray-400">Ages</dt>
+                <dd className="text-gray-900 dark:text-white font-medium">
+                  {pendingImport.profile.currentAge} → {pendingImport.profile.retirementAge}{' '}
+                  → {pendingImport.profile.lifeExpectancy}
+                </dd>
+              </div>
+              {pendingImport.exportedAt && (
+                <div className="flex justify-between gap-4">
+                  <dt className="text-gray-500 dark:text-gray-400">Saved</dt>
+                  <dd className="text-gray-900 dark:text-white font-medium">
+                    {pendingImport.exportedAt.slice(0, 10)}
+                  </dd>
+                </div>
+              )}
+            </dl>
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={cancelImport}
+                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={confirmImport}
+                className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700"
+              >
+                Load Plan
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Import Error Modal */}
+      {importError && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 max-w-md mx-4">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+              Couldn't load that file
+            </h3>
+            <p className="text-gray-600 dark:text-gray-300 mb-4">{importError}</p>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+              Your current plan has not been changed.
+            </p>
+            <div className="flex justify-end">
+              <button
+                onClick={cancelImport}
+                className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700"
+              >
+                OK
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Reset Confirmation Modal */}
       {showResetConfirm && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
@@ -475,7 +685,12 @@ function AppContent() {
                     <ChartAccumulation accounts={accounts} result={accumulation} isDarkMode={isDarkMode} />
                   </div>
 
-                  <DataTableAccumulation accounts={accounts} result={accumulation} />
+                  <DataTableAccumulation
+                    accounts={accounts}
+                    result={accumulation}
+                    profile={profile}
+                    assumptions={assumptions}
+                  />
 
                   <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
                     <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
@@ -510,7 +725,13 @@ function AppContent() {
                     <ChartTax result={retirement} isDarkMode={isDarkMode} />
                   </div>
 
-                  <DataTableWithdrawal accounts={accounts} result={retirement} incomeStreams={incomeStreams} />
+                  <DataTableWithdrawal
+                    accounts={accounts}
+                    result={retirement}
+                    incomeStreams={incomeStreams}
+                    profile={profile}
+                    assumptions={assumptions}
+                  />
                 </div>
               )}
 
@@ -523,6 +744,20 @@ function AppContent() {
         </div>
       </div>
     </Layout>
+
+    {isPrinting && accounts.length > 0 && (
+      <PrintReport
+        accounts={accounts}
+        profile={profile}
+        assumptions={assumptions}
+        incomeStreams={incomeStreams}
+        accumulation={accumulation}
+        retirement={retirement}
+        country={country}
+        generatedAt={printGeneratedAt.current}
+      />
+    )}
+    </>
   );
 }
 
@@ -534,15 +769,15 @@ function App() {
     const defaultProfile = countryConfig.getDefaultProfile();
 
     // Clear localStorage and set new defaults
-    localStorage.setItem('retirement-planner-accounts', JSON.stringify(createDefaultAccounts(newCountry)));
-    localStorage.setItem('retirement-planner-profile', JSON.stringify({
+    localStorage.setItem(STORAGE_KEYS.accounts, JSON.stringify(createDefaultAccounts(newCountry)));
+    localStorage.setItem(STORAGE_KEYS.profile, JSON.stringify({
       ...DEFAULT_PROFILE,
       ...defaultProfile,
       country: newCountry,
     }));
 
     // Reset income streams — default SS for US, empty for Canada
-    localStorage.setItem('retirement-planner-income-streams',
+    localStorage.setItem(STORAGE_KEYS.incomeStreams,
       JSON.stringify(newCountry === 'US' ? DEFAULT_INCOME_STREAMS : [])
     );
 

--- a/src/components/ChartAccumulation.tsx
+++ b/src/components/ChartAccumulation.tsx
@@ -15,6 +15,12 @@ interface ChartAccumulationProps {
   accounts: Account[];
   result: AccumulationResult;
   isDarkMode?: boolean;
+  /**
+   * Recharts reveals series by animating a clip path from zero width. The
+   * print report is captured moments after mount, so animation must be off
+   * or the chart prints blank.
+   */
+  animate?: boolean;
 }
 
 function formatCurrency(value: number): string {
@@ -73,7 +79,7 @@ function CustomTooltip({ active, payload, label, accounts }: CustomTooltipProps)
   );
 }
 
-export function ChartAccumulation({ accounts, result, isDarkMode = false }: ChartAccumulationProps) {
+export function ChartAccumulation({ accounts, result, isDarkMode = false, animate = true }: ChartAccumulationProps) {
   // Colors based on dark mode
   const gridColor = isDarkMode ? '#374151' : '#e5e7eb';
   const tickColor = isDarkMode ? '#9ca3af' : '#6b7280';
@@ -126,6 +132,7 @@ export function ChartAccumulation({ accounts, result, isDarkMode = false }: Char
           />
           {sortedAccounts.map(account => (
             <Area
+              isAnimationActive={animate}
               key={account.id}
               type="monotone"
               dataKey={account.id}

--- a/src/components/ChartComposition.tsx
+++ b/src/components/ChartComposition.tsx
@@ -13,6 +13,12 @@ interface ChartCompositionProps {
   accounts: Account[];
   result: AccumulationResult;
   isDarkMode?: boolean;
+  /**
+   * Recharts reveals series by animating a clip path from zero width. The
+   * print report is captured moments after mount, so animation must be off
+   * or the chart prints blank.
+   */
+  animate?: boolean;
 }
 
 function formatCurrency(value: number): string {
@@ -84,7 +90,7 @@ function renderCustomizedLabel(props: LabelProps) {
   );
 }
 
-export function ChartComposition({ accounts, result, isDarkMode = false }: ChartCompositionProps) {
+export function ChartComposition({ accounts, result, isDarkMode = false, animate = true }: ChartCompositionProps) {
   const { config: countryConfig } = useCountry();
   // Colors based on dark mode
   const labelColor = isDarkMode ? '#9ca3af' : '#374151';
@@ -126,6 +132,7 @@ export function ChartComposition({ accounts, result, isDarkMode = false }: Chart
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie
+                isAnimationActive={animate}
                 data={groupData}
                 cx="50%"
                 cy="50%"
@@ -159,6 +166,7 @@ export function ChartComposition({ accounts, result, isDarkMode = false }: Chart
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie
+                isAnimationActive={animate}
                 data={accountData}
                 cx="50%"
                 cy="50%"

--- a/src/components/ChartDrawdown.tsx
+++ b/src/components/ChartDrawdown.tsx
@@ -15,6 +15,12 @@ interface ChartDrawdownProps {
   accounts: Account[];
   result: RetirementResult;
   isDarkMode?: boolean;
+  /**
+   * Recharts reveals series by animating a clip path from zero width. The
+   * print report is captured moments after mount, so animation must be off
+   * or the chart prints blank.
+   */
+  animate?: boolean;
 }
 
 function formatCurrency(value: number): string {
@@ -83,7 +89,7 @@ function CustomTooltip({ active, payload, label, accounts, result }: CustomToolt
   );
 }
 
-export function ChartDrawdown({ accounts, result, isDarkMode = false }: ChartDrawdownProps) {
+export function ChartDrawdown({ accounts, result, isDarkMode = false, animate = true }: ChartDrawdownProps) {
   // Colors based on dark mode
   const gridColor = isDarkMode ? '#374151' : '#e5e7eb';
   const tickColor = isDarkMode ? '#9ca3af' : '#6b7280';
@@ -136,6 +142,7 @@ export function ChartDrawdown({ accounts, result, isDarkMode = false }: ChartDra
           />
           {sortedAccounts.map(account => (
             <Area
+              isAnimationActive={animate}
               key={account.id}
               type="monotone"
               dataKey={account.id}

--- a/src/components/ChartIncome.tsx
+++ b/src/components/ChartIncome.tsx
@@ -18,6 +18,12 @@ interface ChartIncomeProps {
   result: RetirementResult;
   incomeStreams?: IncomeStream[];
   isDarkMode?: boolean;
+  /**
+   * Recharts reveals series by animating a clip path from zero width. The
+   * print report is captured moments after mount, so animation must be off
+   * or the chart prints blank.
+   */
+  animate?: boolean;
 }
 
 function formatCurrency(value: number): string {
@@ -88,7 +94,7 @@ function CustomTooltip({ active, payload, label, result, currency }: CustomToolt
   );
 }
 
-export function ChartIncome({ result, incomeStreams = [], isDarkMode = false }: ChartIncomeProps) {
+export function ChartIncome({ result, incomeStreams = [], isDarkMode = false, animate = true }: ChartIncomeProps) {
   const { country } = useCountry();
   const isCanada = country === 'CA';
   const currency = isCanada ? 'CAD' : 'USD';
@@ -170,6 +176,7 @@ export function ChartIncome({ result, incomeStreams = [], isDarkMode = false }: 
           <ReferenceLine y={0} stroke="#9ca3af" />
           {/* Gross income components - stacked bars */}
           <Bar
+            isAnimationActive={animate}
             dataKey="withdrawals"
             name="Withdrawals"
             stackId="income"
@@ -177,6 +184,7 @@ export function ChartIncome({ result, incomeStreams = [], isDarkMode = false }: 
             fillOpacity={0.8}
           />
           <Bar
+            isAnimationActive={animate}
             dataKey="socialSecurity"
             name={govBenefitLabel}
             stackId="income"
@@ -185,6 +193,7 @@ export function ChartIncome({ result, incomeStreams = [], isDarkMode = false }: 
           />
           {hasPensionStreams && (
             <Bar
+              isAnimationActive={animate}
               dataKey="pension"
               name="Pension"
               stackId="income"
@@ -194,6 +203,7 @@ export function ChartIncome({ result, incomeStreams = [], isDarkMode = false }: 
           )}
           {hasOtherIncomeStreams && (
             <Bar
+              isAnimationActive={animate}
               dataKey="otherIncome"
               name="Other Income"
               stackId="income"
@@ -203,6 +213,7 @@ export function ChartIncome({ result, incomeStreams = [], isDarkMode = false }: 
           )}
           {hasTaxFreeStreams && (
             <Bar
+              isAnimationActive={animate}
               dataKey="taxFreeIncome"
               name="Tax-Free Income"
               stackId="income"
@@ -212,6 +223,7 @@ export function ChartIncome({ result, incomeStreams = [], isDarkMode = false }: 
           )}
           {/* After-tax income line - the key metric */}
           <Line
+            isAnimationActive={animate}
             type="monotone"
             dataKey="afterTax"
             name="After-Tax Income"
@@ -221,6 +233,7 @@ export function ChartIncome({ result, incomeStreams = [], isDarkMode = false }: 
           />
           {/* Taxes as a separate line for reference */}
           <Line
+            isAnimationActive={animate}
             type="monotone"
             dataKey="taxes"
             name="Taxes Paid"

--- a/src/components/ChartTax.tsx
+++ b/src/components/ChartTax.tsx
@@ -15,6 +15,12 @@ import { CHART_COLORS } from '../utils/constants';
 interface ChartTaxProps {
   result: RetirementResult;
   isDarkMode?: boolean;
+  /**
+   * Recharts reveals series by animating a clip path from zero width. The
+   * print report is captured moments after mount, so animation must be off
+   * or the chart prints blank.
+   */
+  animate?: boolean;
 }
 
 function formatCurrency(value: number): string {
@@ -85,7 +91,7 @@ function CustomTooltip({ active, payload, label, result }: CustomTooltipProps) {
   );
 }
 
-export function ChartTax({ result, isDarkMode = false }: ChartTaxProps) {
+export function ChartTax({ result, isDarkMode = false, animate = true }: ChartTaxProps) {
   // Colors based on dark mode
   const gridColor = isDarkMode ? '#374151' : '#e5e7eb';
   const tickColor = isDarkMode ? '#9ca3af' : '#6b7280';
@@ -140,6 +146,7 @@ export function ChartTax({ result, isDarkMode = false }: ChartTaxProps) {
             formatter={(value) => <span style={{ color: tickColor }}>{value}</span>}
           />
           <Bar
+            isAnimationActive={animate}
             yAxisId="left"
             dataKey="federalTax"
             name="Federal Tax"
@@ -148,6 +155,7 @@ export function ChartTax({ result, isDarkMode = false }: ChartTaxProps) {
             fillOpacity={0.8}
           />
           <Bar
+            isAnimationActive={animate}
             yAxisId="left"
             dataKey="stateTax"
             name="State Tax"
@@ -156,6 +164,7 @@ export function ChartTax({ result, isDarkMode = false }: ChartTaxProps) {
             fillOpacity={0.8}
           />
           <Line
+            isAnimationActive={animate}
             yAxisId="right"
             type="monotone"
             dataKey="effectiveRate"

--- a/src/components/CsvDownloadButton.tsx
+++ b/src/components/CsvDownloadButton.tsx
@@ -1,0 +1,34 @@
+import { csvFilename, downloadCsv, toCsv } from '../utils/export';
+import type { ExportTable } from '../utils/export';
+
+interface CsvDownloadButtonProps {
+  /** Built lazily on click — no cost while the panel just sits there. */
+  getTable: () => ExportTable;
+  label?: string;
+}
+
+export function CsvDownloadButton({ getTable, label = 'Download CSV' }: CsvDownloadButtonProps) {
+  const handleClick = () => {
+    const table = getTable();
+    downloadCsv(csvFilename(table), toCsv(table));
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      title="Download this table as a CSV file"
+      className="no-print flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors whitespace-nowrap"
+    >
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+        />
+      </svg>
+      {label}
+    </button>
+  );
+}

--- a/src/components/DataTableAccumulation.tsx
+++ b/src/components/DataTableAccumulation.tsx
@@ -1,11 +1,15 @@
 import { useState } from 'react';
-import { Account, AccumulationResult, getTaxTreatment } from '../types';
-import { is401k } from '../types';
+import { Account, AccumulationResult, Assumptions, Profile, getTaxTreatment } from '../types';
 import { useCountry } from '../contexts/CountryContext';
+import { getEmployerMatch, supportsEmployerMatch } from '../utils/projections';
+import { buildAccumulationTable, buildExportMeta } from '../utils/export';
+import { CsvDownloadButton } from './CsvDownloadButton';
 
 interface DataTableAccumulationProps {
   accounts: Account[];
   result: AccumulationResult;
+  profile: Profile;
+  assumptions: Assumptions;
 }
 
 function formatCurrencyWithCode(value: number, currency: string = 'USD'): string {
@@ -18,7 +22,12 @@ function formatCurrencyWithCode(value: number, currency: string = 'USD'): string
 
 type ViewMode = 'summary' | 'balances' | 'contributions';
 
-export function DataTableAccumulation({ accounts, result }: DataTableAccumulationProps) {
+export function DataTableAccumulation({
+  accounts,
+  result,
+  profile,
+  assumptions,
+}: DataTableAccumulationProps) {
   const { country } = useCountry();
   const currency = country === 'CA' ? 'CAD' : 'USD';
   const formatCurrency = (value: number) => formatCurrencyWithCode(value, currency);
@@ -28,14 +37,13 @@ export function DataTableAccumulation({ accounts, result }: DataTableAccumulatio
 
   if (!result.yearlyBalances.length) return null;
 
-  // Calculate employer match for each account/year
-  const getEmployerMatch = (account: Account, contribution: number): number => {
-    if (!is401k(account.type) || !account.employerMatchPercent || !account.employerMatchLimit) {
-      return 0;
-    }
-    const matchAmount = contribution * account.employerMatchPercent;
-    return Math.min(matchAmount, account.employerMatchLimit);
-  };
+  const buildCsvTable = () =>
+    buildAccumulationTable(
+      viewMode,
+      accounts,
+      result,
+      buildExportMeta(profile, assumptions, country)
+    );
 
   // Get color class based on tax treatment
   const getColorClass = (accountType: Account['type']): string => {
@@ -78,7 +86,7 @@ export function DataTableAccumulation({ accounts, result }: DataTableAccumulatio
       {isExpanded && (
         <div className="px-4 pb-4">
           {/* View Mode Tabs */}
-          <div className="flex gap-2 mb-4 border-b border-gray-200 dark:border-gray-700">
+          <div className="flex gap-2 mb-4 border-b border-gray-200 dark:border-gray-700 items-center">
             <button
               onClick={() => setViewMode('summary')}
               className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px ${
@@ -109,6 +117,10 @@ export function DataTableAccumulation({ accounts, result }: DataTableAccumulatio
             >
               Contributions
             </button>
+
+            <div className="ml-auto pb-2">
+              <CsvDownloadButton getTable={buildCsvTable} />
+            </div>
           </div>
 
           <div className="overflow-x-auto">
@@ -189,7 +201,7 @@ export function DataTableAccumulation({ accounts, result }: DataTableAccumulatio
                     {accounts.map(acc => (
                       <th key={acc.id} className={`text-right py-2 px-2 font-medium ${getColorClass(acc.type)}`}>
                         {acc.name}
-                        {is401k(acc.type) && acc.employerMatchPercent ? ' (+Match)' : ''}
+                        {supportsEmployerMatch(acc) ? ' (+Match)' : ''}
                       </th>
                     ))}
                     <th className="text-right py-2 px-2 font-medium text-gray-700 dark:text-gray-300">Total</th>

--- a/src/components/DataTableWithdrawal.tsx
+++ b/src/components/DataTableWithdrawal.tsx
@@ -1,12 +1,24 @@
-import { useState } from 'react';
-import { Account, RetirementResult, IncomeStream, IncomeTaxTreatment, getTaxTreatment } from '../types';
+import { Fragment, useState } from 'react';
+import {
+  Account,
+  Assumptions,
+  RetirementResult,
+  IncomeStream,
+  IncomeTaxTreatment,
+  Profile,
+  getTaxTreatment,
+} from '../types';
 import { CHART_COLORS } from '../utils/constants';
 import { useCountry } from '../contexts/CountryContext';
+import { buildExportMeta, buildWithdrawalTable } from '../utils/export';
+import { CsvDownloadButton } from './CsvDownloadButton';
 
 interface DataTableWithdrawalProps {
   accounts: Account[];
   result: RetirementResult;
   incomeStreams?: IncomeStream[];
+  profile: Profile;
+  assumptions: Assumptions;
 }
 
 function formatCurrencyWithCode(value: number, currency: string = 'USD'): string {
@@ -24,7 +36,13 @@ function formatPercent(value: number): string {
 
 type ViewMode = 'income' | 'withdrawals' | 'balances' | 'taxes' | 'incomeStreams';
 
-export function DataTableWithdrawal({ accounts, result, incomeStreams = [] }: DataTableWithdrawalProps) {
+export function DataTableWithdrawal({
+  accounts,
+  result,
+  incomeStreams = [],
+  profile,
+  assumptions,
+}: DataTableWithdrawalProps) {
   const { country } = useCountry();
   const currency = country === 'CA' ? 'CAD' : 'USD';
   const formatCurrency = (value: number) => formatCurrencyWithCode(value, currency);
@@ -46,6 +64,15 @@ export function DataTableWithdrawal({ accounts, result, incomeStreams = [] }: Da
   };
 
   if (!result.yearlyWithdrawals.length) return null;
+
+  const buildCsvTable = () =>
+    buildWithdrawalTable(
+      viewMode,
+      accounts,
+      result,
+      incomeStreams,
+      buildExportMeta(profile, assumptions, country)
+    );
 
   // Get color class based on account tax treatment
   const getColorClass = (accountType: Account['type']): string => {
@@ -98,7 +125,7 @@ export function DataTableWithdrawal({ accounts, result, incomeStreams = [] }: Da
       {isExpanded && (
         <div className="px-4 pb-4">
           {/* View Mode Tabs */}
-          <div className="flex gap-2 mb-4 border-b border-gray-200 dark:border-gray-700 overflow-x-auto">
+          <div className="flex gap-2 mb-4 border-b border-gray-200 dark:border-gray-700 overflow-x-auto items-center">
             <button
               onClick={() => setViewMode('income')}
               className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px whitespace-nowrap ${
@@ -149,6 +176,10 @@ export function DataTableWithdrawal({ accounts, result, incomeStreams = [] }: Da
             >
               Income Streams
             </button>
+
+            <div className="ml-auto pb-2">
+              <CsvDownloadButton getTable={buildCsvTable} />
+            </div>
           </div>
 
           <div className="overflow-x-auto">
@@ -289,8 +320,10 @@ export function DataTableWithdrawal({ accounts, result, incomeStreams = [] }: Da
                     const hasPenalties = yearData.totalPenalties > 0;
                     const isPenaltyExpanded = expandedPenaltyRows.has(yearData.age);
                     return (
-                      <>
-                        <tr key={yearData.age} className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                      // The key belongs on the fragment, not the inner rows —
+                      // React never sees a keyed child otherwise.
+                      <Fragment key={yearData.age}>
+                        <tr className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700/50">
                           <td className="py-2 px-2 font-medium text-gray-900 dark:text-white sticky left-0 bg-white dark:bg-gray-800">{yearData.age}</td>
                           <td className="py-2 px-2 text-right font-mono text-gray-900 dark:text-white">{formatCurrency(yearData.grossIncome)}</td>
                           <td className="py-2 px-2 text-right font-mono text-red-600 dark:text-red-400">{formatCurrency(yearData.federalTax)}</td>
@@ -316,7 +349,7 @@ export function DataTableWithdrawal({ accounts, result, incomeStreams = [] }: Da
                           <td className="py-2 px-2 text-right font-mono text-gray-600 dark:text-gray-400">{formatPercent(effectiveRate)}</td>
                         </tr>
                         {hasPenalties && isPenaltyExpanded && yearData.earlyWithdrawalPenalties.length > 0 && (
-                          <tr key={`${yearData.age}-penalties`} className="border-b border-gray-100 dark:border-gray-800 bg-red-50 dark:bg-red-900/10">
+                          <tr className="border-b border-gray-100 dark:border-gray-800 bg-red-50 dark:bg-red-900/10">
                             <td colSpan={7} className="py-2 px-2">
                               <div className="pl-4 border-l-2 border-red-300 dark:border-red-700">
                                 <p className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Early Withdrawal Penalty Details:</p>
@@ -332,7 +365,7 @@ export function DataTableWithdrawal({ accounts, result, incomeStreams = [] }: Da
                             </td>
                           </tr>
                         )}
-                      </>
+                      </Fragment>
                     );
                   })}
                 </tbody>

--- a/src/components/ExportMenu.tsx
+++ b/src/components/ExportMenu.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useRef, useState } from 'react';
+
+export interface ExportMenuActions {
+  onSavePlan: () => void;
+  onLoadPlanFile: (file: File) => void;
+  onPrintReport: () => void;
+}
+
+interface ExportMenuProps extends ExportMenuActions {
+  /** Renders as a full-width list instead of a dropdown (mobile menu). */
+  inline?: boolean;
+  onAfterAction?: () => void;
+}
+
+const ITEMS = [
+  {
+    id: 'save',
+    label: 'Save plan (.json)',
+    description: 'Download everything you have entered',
+    icon: (
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+      />
+    ),
+  },
+  {
+    id: 'load',
+    label: 'Load plan (.json)',
+    description: 'Replace the current plan from a file',
+    icon: (
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
+      />
+    ),
+  },
+  {
+    id: 'print',
+    label: 'Print / Save as PDF',
+    description: 'Full report with charts and tables',
+    icon: (
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"
+      />
+    ),
+  },
+] as const;
+
+export function ExportMenu({
+  onSavePlan,
+  onLoadPlanFile,
+  onPrintReport,
+  inline = false,
+  onAfterAction,
+}: ExportMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsOpen(false);
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
+  const runAction = (id: (typeof ITEMS)[number]['id']) => {
+    setIsOpen(false);
+    if (id === 'save') {
+      onSavePlan();
+      onAfterAction?.();
+    } else if (id === 'load') {
+      fileInputRef.current?.click();
+    } else {
+      onPrintReport();
+      onAfterAction?.();
+    }
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    // Reset so picking the same file twice still fires a change event.
+    event.target.value = '';
+    if (file) {
+      onLoadPlanFile(file);
+      onAfterAction?.();
+    }
+  };
+
+  const hiddenInput = (
+    <input
+      ref={fileInputRef}
+      type="file"
+      accept="application/json,.json"
+      onChange={handleFileChange}
+      className="hidden"
+    />
+  );
+
+  if (inline) {
+    return (
+      <>
+        {hiddenInput}
+        {ITEMS.map(item => (
+          <button
+            key={item.id}
+            onClick={() => runAction(item.id)}
+            className="w-full px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-3"
+          >
+            <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              {item.icon}
+            </svg>
+            {item.label}
+          </button>
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <div className="relative" ref={containerRef}>
+      {hiddenInput}
+      <button
+        onClick={() => setIsOpen(open => !open)}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        title="Export or load a plan"
+        className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+          />
+        </svg>
+        Export
+        <svg
+          className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div
+          role="menu"
+          className="absolute right-0 mt-2 w-64 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg py-2 z-50"
+        >
+          {ITEMS.map(item => (
+            <button
+              key={item.id}
+              role="menuitem"
+              onClick={() => runAction(item.id)}
+              className="w-full px-4 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700 flex items-start gap-3"
+            >
+              <svg
+                className="w-5 h-5 mt-0.5 shrink-0 text-gray-500 dark:text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                {item.icon}
+              </svg>
+              <span>
+                <span className="block text-sm font-medium text-gray-900 dark:text-white">
+                  {item.label}
+                </span>
+                <span className="block text-xs text-gray-500 dark:text-gray-400">
+                  {item.description}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,19 +1,28 @@
 import { ReactNode, useState } from 'react';
 import { CountrySelector } from './CountrySelector';
 import { TAX_DATA_YEAR } from '../utils/constants';
+import { ExportMenu, type ExportMenuActions } from './ExportMenu';
 
 interface LayoutProps {
   children: ReactNode;
   isDarkMode: boolean;
   onToggleDarkMode: () => void;
   onReset: () => void;
+  exportActions: ExportMenuActions;
 }
 
-export function Layout({ children, isDarkMode, onToggleDarkMode, onReset }: LayoutProps) {
+export function Layout({
+  children,
+  isDarkMode,
+  onToggleDarkMode,
+  onReset,
+  exportActions,
+}: LayoutProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-200">
+    // `no-print` hides the whole interactive app while the print report renders.
+    <div className="no-print min-h-screen bg-gray-50 dark:bg-gray-900 transition-colors duration-200">
       {/* Header */}
       <header className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
@@ -55,6 +64,9 @@ export function Layout({ children, isDarkMode, onToggleDarkMode, onReset }: Layo
 
               {/* Divider */}
               <div className="w-px h-6 bg-gray-300 dark:bg-gray-600"></div>
+
+              {/* Export / Import / Print */}
+              <ExportMenu {...exportActions} />
 
               {/* Reset Button */}
               <button
@@ -99,7 +111,15 @@ export function Layout({ children, isDarkMode, onToggleDarkMode, onReset }: Layo
 
               {/* Dropdown menu */}
               {isMenuOpen && (
-                <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg py-2 z-50">
+                <div className="absolute right-0 mt-2 w-56 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg py-2 z-50">
+                  <ExportMenu
+                    {...exportActions}
+                    inline
+                    onAfterAction={() => setIsMenuOpen(false)}
+                  />
+
+                  <div className="my-2 border-t border-gray-200 dark:border-gray-700" />
+
                   <button
                     onClick={() => {
                       onReset();

--- a/src/components/PrintReport.tsx
+++ b/src/components/PrintReport.tsx
@@ -1,0 +1,260 @@
+import {
+  Account,
+  AccumulationResult,
+  Assumptions,
+  IncomeStream,
+  Profile,
+  RetirementResult,
+} from '../types';
+import type { CountryCode } from '../countries';
+import { TAX_DATA_YEAR } from '../utils/constants';
+import {
+  buildAccountsTable,
+  buildAccumulationTable,
+  buildExportMeta,
+  buildIncomeStreamsTable,
+  buildWithdrawalTable,
+  formatCell,
+} from '../utils/export';
+import type { ExportTable } from '../utils/export';
+import { SummaryCards } from './SummaryCards';
+import { MethodologyPanel } from './MethodologyPanel';
+import { ChartAccumulation } from './ChartAccumulation';
+import { ChartComposition } from './ChartComposition';
+import { ChartDrawdown } from './ChartDrawdown';
+import { ChartIncome } from './ChartIncome';
+import { ChartTax } from './ChartTax';
+
+interface PrintReportProps {
+  accounts: Account[];
+  profile: Profile;
+  assumptions: Assumptions;
+  incomeStreams: IncomeStream[];
+  accumulation: AccumulationResult;
+  retirement: RetirementResult;
+  country: CountryCode;
+  generatedAt: Date;
+}
+
+function PrintTable({ table }: { table: ExportTable }) {
+  const { currency } = table.meta;
+
+  return (
+    <div className="print-block mb-6">
+      <h3 className="text-base font-semibold text-gray-900 mb-2">{table.title}</h3>
+      <table className="w-full text-[10px] border-collapse">
+        <thead>
+          <tr className="border-b-2 border-gray-400">
+            {table.columns.map(column => (
+              <th
+                key={column.key}
+                className={`py-1 px-1 font-semibold text-gray-800 ${
+                  column.type === 'text' ? 'text-left' : 'text-right'
+                }`}
+              >
+                {column.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {table.rows.map((row, index) => (
+            <tr key={index} className="border-b border-gray-200">
+              {table.columns.map(column => (
+                <td
+                  key={column.key}
+                  className={`py-0.5 px-1 text-gray-700 ${
+                    column.type === 'text' ? 'text-left' : 'text-right tabular-nums'
+                  }`}
+                >
+                  {formatCell(row[column.key], column.type, currency)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+        {table.footer && (
+          <tfoot>
+            <tr className="border-t-2 border-gray-400 font-semibold">
+              {table.columns.map(column => (
+                <td
+                  key={column.key}
+                  className={`py-1 px-1 text-gray-900 ${
+                    column.type === 'text' ? 'text-left' : 'text-right tabular-nums'
+                  }`}
+                >
+                  {formatCell(table.footer![column.key], column.type, currency)}
+                </td>
+              ))}
+            </tr>
+          </tfoot>
+        )}
+      </table>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="print-section">
+      <h2 className="text-lg font-bold text-gray-900 border-b-2 border-gray-800 pb-1 mb-4">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between gap-4 py-1 border-b border-gray-200 text-sm">
+      <span className="text-gray-600">{label}</span>
+      <span className="font-medium text-gray-900 tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+export function PrintReport({
+  accounts,
+  profile,
+  assumptions,
+  incomeStreams,
+  accumulation,
+  retirement,
+  country,
+  generatedAt,
+}: PrintReportProps) {
+  const meta = buildExportMeta(profile, assumptions, country, generatedAt);
+  const percent = (value: number) => `${(value * 100).toFixed(1)}%`;
+
+  const dateLabel = generatedAt.toLocaleDateString(country === 'CA' ? 'en-CA' : 'en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  return (
+    // Charts measure their container, so the report is laid out at a fixed
+    // 720px (7.5in at 96dpi) both off-screen and on paper.
+    <div className="print-report bg-white text-gray-900">
+      {/* Cover */}
+      <header className="print-block mb-8">
+        <h1 className="text-3xl font-bold text-gray-900">Retirement Plan</h1>
+        <p className="text-sm text-gray-600 mt-1">
+          Generated {dateLabel} · {country === 'CA' ? 'Canada' : 'United States'} ·{' '}
+          {meta.currency}
+        </p>
+        <p className="text-xs text-gray-500 mt-4 border border-gray-300 rounded p-3 leading-relaxed">
+          <strong>Dollar amounts are nominal (future) dollars</strong> unless labelled
+          &ldquo;real&rdquo; or &ldquo;today&rsquo;s dollars&rdquo;. Nominal figures include{' '}
+          {percent(assumptions.inflationRate)} annual inflation, so later years look larger
+          than their purchasing power. Tax brackets are not indexed to inflation in this
+          model ({TAX_DATA_YEAR} brackets are held constant), which overstates the tax
+          burden in later years. This report provides estimates only — consult a financial
+          advisor for personalized advice.
+        </p>
+      </header>
+
+      <Section title="Plan Inputs">
+        <div className="grid grid-cols-2 gap-x-8 mb-6">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-800 mb-1">Profile</h3>
+            <Field label="Current age" value={String(profile.currentAge)} />
+            <Field label="Retirement age" value={String(profile.retirementAge)} />
+            <Field label="Life expectancy" value={String(profile.lifeExpectancy)} />
+            <Field label={country === 'CA' ? 'Province' : 'State'} value={profile.region} />
+            {profile.filingStatus && (
+              <Field
+                label="Filing status"
+                value={
+                  profile.filingStatus === 'married_filing_jointly'
+                    ? 'Married filing jointly'
+                    : 'Single'
+                }
+              />
+            )}
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-gray-800 mb-1">Assumptions</h3>
+            <Field label="Inflation" value={percent(assumptions.inflationRate)} />
+            <Field
+              label="Safe withdrawal rate"
+              value={percent(assumptions.safeWithdrawalRate)}
+            />
+            <Field
+              label="Retirement return"
+              value={percent(assumptions.retirementReturnRate)}
+            />
+          </div>
+        </div>
+
+        <PrintTable table={buildAccountsTable(accounts, meta)} />
+        {incomeStreams.length > 0 && (
+          <PrintTable table={buildIncomeStreamsTable(incomeStreams, meta)} />
+        )}
+      </Section>
+
+      <Section title="Summary">
+        {/* SummaryCards lays out up to 4 columns at the `md` breakpoint, which
+            keys off the viewport rather than this 720px container. See the
+            .print-summary rule in index.css. */}
+        <div className="print-summary">
+          <SummaryCards
+            profile={profile}
+            assumptions={assumptions}
+            accumulationResult={accumulation}
+            retirementResult={retirement}
+          />
+        </div>
+        <div className="print-block mt-6">
+          <h3 className="text-base font-semibold text-gray-900 mb-2">
+            Portfolio Composition at Retirement
+          </h3>
+          <ChartComposition accounts={accounts} result={accumulation} isDarkMode={false} animate={false} />
+        </div>
+      </Section>
+
+      <Section title="Accumulation Phase">
+        <div className="print-block mb-6">
+          <h3 className="text-base font-semibold text-gray-900 mb-2">
+            Account Growth (Age {profile.currentAge} to {profile.retirementAge})
+          </h3>
+          <ChartAccumulation accounts={accounts} result={accumulation} isDarkMode={false} animate={false} />
+        </div>
+        <PrintTable table={buildAccumulationTable('summary', accounts, accumulation, meta)} />
+      </Section>
+
+      <Section title="Retirement Phase">
+        <div className="print-block mb-6">
+          <h3 className="text-base font-semibold text-gray-900 mb-2">
+            Portfolio Drawdown (Age {profile.retirementAge} to {profile.lifeExpectancy})
+          </h3>
+          <ChartDrawdown accounts={accounts} result={retirement} isDarkMode={false} animate={false} />
+        </div>
+        <div className="print-block mb-6">
+          <h3 className="text-base font-semibold text-gray-900 mb-2">
+            Annual Retirement Income
+          </h3>
+          <ChartIncome result={retirement} incomeStreams={incomeStreams} isDarkMode={false} animate={false} />
+        </div>
+        <PrintTable
+          table={buildWithdrawalTable('income', accounts, retirement, incomeStreams, meta)}
+        />
+      </Section>
+
+      <Section title="Taxes">
+        <div className="print-block mb-6">
+          <h3 className="text-base font-semibold text-gray-900 mb-2">Tax Burden Over Time</h3>
+          <ChartTax result={retirement} isDarkMode={false} animate={false} />
+        </div>
+        <PrintTable
+          table={buildWithdrawalTable('taxes', accounts, retirement, incomeStreams, meta)}
+        />
+      </Section>
+
+      <Section title="Methodology">
+        <MethodologyPanel profile={profile} assumptions={assumptions} />
+      </Section>
+    </div>
+  );
+}

--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { AccumulationResult, RetirementResult, Profile, Assumptions } from '../types';
 import { STANDARD_DEDUCTION_MFJ, STANDARD_DEDUCTION_SINGLE } from '../utils/constants';
 import { useCountry } from '../contexts/CountryContext';
+import { presentValue } from '../utils/export/realDollars';
 
 interface SummaryCardsProps {
   profile: Profile;
@@ -20,12 +21,6 @@ function formatCurrencyWithCode(value: number, currency: string = 'USD'): string
 
 function formatPercent(value: number): string {
   return `${(value * 100).toFixed(1)}%`;
-}
-
-// Convert a future nominal amount to its present (today's-dollar) value.
-function presentValue(nominalAmount: number, yearsFromNow: number, inflationRate: number): number {
-  if (yearsFromNow <= 0) return nominalAmount;
-  return nominalAmount / Math.pow(1 + inflationRate, yearsFromNow);
 }
 
 // Build the "≈ $X today" secondary line. Returns undefined when nominal and

--- a/src/index.css
+++ b/src/index.css
@@ -67,3 +67,82 @@ body {
 .scrollbar-hide::-webkit-scrollbar {
   display: none;
 }
+
+/* ---------------------------------------------------------------------------
+   Print report
+
+   The report is mounted off-screen at a fixed 720px (7.5in at 96dpi) so that
+   Recharts' ResponsiveContainer measures a real printable width before the
+   print dialog opens — it cannot measure an element with no layout. A negative
+   `left` keeps it out of sight without creating a horizontal scrollbar.
+
+   Dark mode is turned off by removing the `.dark` class while printing (see
+   App.tsx), so these rules only ever deal with the light palette.
+--------------------------------------------------------------------------- */
+.print-report {
+  position: absolute;
+  left: -10000px;
+  top: 0;
+  width: 720px;
+}
+
+/*
+ * SummaryCards switches to 3- and 4-column grids at Tailwind's `md` breakpoint,
+ * which measures the viewport — not this fixed 720px container — so on a wide
+ * screen the cards would overflow the page. Pin them to two columns.
+ */
+.print-report .print-summary .grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+/* The summary cards' expand chevrons are an interactive affordance with no
+   meaning on paper. */
+.print-report button[aria-label*='calculation details'] {
+  display: none;
+}
+
+@media print {
+  @page {
+    size: letter portrait;
+    margin: 0.5in;
+  }
+
+  /* Hide the interactive app and any in-report controls. */
+  .no-print {
+    display: none !important;
+  }
+
+  body {
+    background: #fff !important;
+  }
+
+  .print-report {
+    position: static;
+    left: auto;
+    /* Keep chart fills and card backgrounds instead of dropping to white. */
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  /* Each major section starts on a fresh page (but not the first). */
+  .print-section + .print-section {
+    break-before: page;
+  }
+
+  /* Don't split a chart or table header away from its content. */
+  .print-block {
+    break-inside: avoid;
+  }
+
+  .print-report table {
+    break-inside: auto;
+  }
+
+  .print-report tr {
+    break-inside: avoid;
+  }
+
+  .print-report thead {
+    display: table-header-group;
+  }
+}

--- a/src/tests/export.test.ts
+++ b/src/tests/export.test.ts
@@ -1,0 +1,752 @@
+/**
+ * Export Feature Tests
+ *
+ * Covers scenario save/load round-tripping and validation, CSV serialization,
+ * and the nominal -> real conversion used by the exports.
+ *
+ * Run with: npx tsx src/tests/export.test.ts
+ */
+
+import { Account, Assumptions, IncomeStream, Profile } from '../types';
+import { getCountryConfig } from '../countries';
+import { calculateAccumulation } from '../utils/projections';
+import { calculateWithdrawals } from '../utils/withdrawals';
+import { inflationFactor, presentValue } from '../utils/export/realDollars';
+import { csvFilename, toCsv } from '../utils/export/csv';
+import {
+  buildAccumulationTable,
+  buildExportMeta,
+  buildWithdrawalTable,
+} from '../utils/export/tables';
+import {
+  SCENARIO_SCHEMA_VERSION,
+  buildScenario,
+  parseScenario,
+  scenarioFilename,
+} from '../utils/export/scenario';
+import type { ExportTable } from '../utils/export/types';
+
+// Test utilities
+let passedTests = 0;
+let failedTests = 0;
+
+function assert(condition: boolean, message: string): void {
+  if (condition) {
+    console.log(`  ✓ ${message}`);
+    passedTests++;
+  } else {
+    console.error(`  ✗ ${message}`);
+    failedTests++;
+  }
+}
+
+function assertApprox(actual: number, expected: number, tolerance: number, message: string): void {
+  const diff = Math.abs(actual - expected);
+  if (diff <= tolerance) {
+    console.log(`  ✓ ${message} (got ${actual.toFixed(2)}, expected ${expected.toFixed(2)})`);
+    passedTests++;
+  } else {
+    console.error(`  ✗ ${message} (got ${actual.toFixed(2)}, expected ${expected.toFixed(2)}, diff: ${diff.toFixed(2)})`);
+    failedTests++;
+  }
+}
+
+function assertEqual(actual: unknown, expected: unknown, message: string): void {
+  if (actual === expected) {
+    console.log(`  ✓ ${message}`);
+    passedTests++;
+  } else {
+    console.error(`  ✗ ${message} (got ${JSON.stringify(actual)}, expected ${JSON.stringify(expected)})`);
+    failedTests++;
+  }
+}
+
+function section(name: string): void {
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`${name}`);
+  console.log('='.repeat(60));
+}
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const usConfig = getCountryConfig('US');
+
+const testAccounts: Account[] = [
+  {
+    id: 'acc-401k',
+    name: 'Company 401(k)',
+    type: 'traditional_401k',
+    balance: 150000,
+    annualContribution: 15000,
+    contributionGrowthRate: 0.03,
+    returnRate: 0.07,
+    employerMatchPercent: 0.5,
+    employerMatchLimit: 3000,
+    withdrawalRules: { startAge: 60 },
+  },
+  {
+    id: 'acc-roth',
+    name: 'Roth IRA',
+    type: 'roth_ira',
+    balance: 40000,
+    annualContribution: 7000,
+    contributionGrowthRate: 0,
+    returnRate: 0.07,
+    withdrawalRules: { startAge: 60 },
+  },
+];
+
+const testProfile: Profile = {
+  country: 'US',
+  currentAge: 35,
+  retirementAge: 65,
+  lifeExpectancy: 90,
+  region: 'CA',
+  filingStatus: 'married_filing_jointly',
+  stateTaxRate: 0.05,
+};
+
+const testAssumptions: Assumptions = {
+  inflationRate: 0.03,
+  safeWithdrawalRate: 0.04,
+  retirementReturnRate: 0.05,
+};
+
+const testIncomeStreams: IncomeStream[] = [
+  {
+    id: 'stream-ss',
+    name: 'Social Security',
+    monthlyAmount: 2500,
+    startAge: 67,
+    taxTreatment: 'social_security',
+  },
+];
+
+const FIXED_DATE = new Date('2026-07-29T12:00:00.000Z');
+
+const accumulation = calculateAccumulation(testAccounts, testProfile, usConfig);
+const retirement = calculateWithdrawals(
+  testAccounts,
+  testProfile,
+  testAssumptions,
+  accumulation,
+  usConfig,
+  testIncomeStreams
+);
+const meta = buildExportMeta(testProfile, testAssumptions, 'US', FIXED_DATE);
+
+/** Split a CSV into its data block and its trailing metadata block. */
+function splitCsv(csv: string): { header: string; body: string[]; metaLines: string[] } {
+  const lines = csv.replace(/^\uFEFF/, '').split('\r\n');
+  const blankIndex = lines.indexOf('');
+  const dataLines = lines.slice(0, blankIndex);
+  return {
+    header: dataLines[0],
+    body: dataLines.slice(1),
+    metaLines: lines.slice(blankIndex + 1).filter(line => line.length > 0),
+  };
+}
+
+// =============================================================================
+// REAL DOLLARS
+// =============================================================================
+
+function testRealDollars(): void {
+  section('NOMINAL VS REAL CONVERSION');
+
+  assertEqual(inflationFactor(0, 0.03), 1, 'Inflation factor is 1 at year 0');
+  assertEqual(inflationFactor(-5, 0.03), 1, 'Inflation factor is 1 for past years');
+  assertApprox(inflationFactor(25, 0.03), 2.0938, 0.001, '25 years at 3% compounds to ~2.094x');
+  assertApprox(inflationFactor(30, 0), 1, 0.0001, 'Zero inflation never deflates');
+
+  assertApprox(
+    presentValue(1_000_000, 25, 0.03),
+    477_605.57,
+    1,
+    '$1M in 25 years is ~$478k today at 3%'
+  );
+  assertEqual(presentValue(50_000, 0, 0.03), 50_000, 'Present value at year 0 is unchanged');
+
+  // Round trip
+  const nominal = 123_456.78;
+  assertApprox(
+    presentValue(nominal, 12, 0.025) * inflationFactor(12, 0.025),
+    nominal,
+    0.01,
+    'Deflating then reinflating returns the original amount'
+  );
+}
+
+// =============================================================================
+// CSV SERIALIZATION
+// =============================================================================
+
+function testCsvEscaping(): void {
+  section('CSV ESCAPING');
+
+  const trickyAccounts: Account[] = [
+    { ...testAccounts[0], id: 'a1', name: 'Smith, John "Jr"' },
+    { ...testAccounts[1], id: 'a2', name: '=HYPERLINK("http://evil","click")' },
+  ];
+  const trickyAccumulation = calculateAccumulation(trickyAccounts, testProfile, usConfig);
+  const table = buildAccumulationTable('balances', trickyAccounts, trickyAccumulation, meta);
+  const { header } = splitCsv(toCsv(table));
+
+  assert(
+    header.includes('"Smith, John ""Jr"""'),
+    'Commas and quotes in account names are escaped'
+  );
+  assert(
+    header.includes(`"'=HYPERLINK`),
+    'Formula-leading account names are neutralized with an apostrophe'
+  );
+
+  // Newlines
+  const newlineTable: ExportTable = {
+    id: 'test',
+    title: 'Test',
+    columns: [{ key: 'note', label: 'Note', type: 'text' }],
+    rows: [{ note: 'line one\nline two' }],
+    meta,
+  };
+  const { body } = splitCsv(toCsv(newlineTable));
+  assert(
+    body[0].startsWith('"line one'),
+    'Embedded newlines are quoted rather than breaking the row'
+  );
+}
+
+function testCsvStructure(): void {
+  section('CSV STRUCTURE');
+
+  const table = buildAccumulationTable('summary', testAccounts, accumulation, meta);
+  const csv = toCsv(table);
+
+  assert(csv.startsWith('\uFEFF'), 'CSV starts with a UTF-8 BOM for Excel');
+  assert(csv.includes('\r\n'), 'CSV uses CRLF line endings (RFC 4180)');
+
+  const { header, body, metaLines } = splitCsv(csv);
+  assertEqual(
+    header,
+    'Age,Year,Total Balance,Total Balance (Real),Year Growth,Total Contributions,Total Contributions (Real),Inflation Factor',
+    'Header row is the first line, so spreadsheets auto-detect it'
+  );
+  assertEqual(
+    body.length,
+    accumulation.yearlyBalances.length,
+    'One data row per projected year'
+  );
+  assert(
+    metaLines.every(line => line.startsWith('#')),
+    'Metadata lines come after a blank line and are all comment-prefixed'
+  );
+  assert(
+    metaLines.some(line => line.includes('Inflation rate') && line.includes('3.00%')),
+    'Metadata records the inflation rate used'
+  );
+  assert(
+    metaLines.some(line => line.includes('bracket creep')),
+    'Metadata warns that nominal tax figures include bracket creep'
+  );
+
+  assertEqual(
+    csvFilename(table),
+    'retirement-planner-accumulation-summary-2026-07-29.csv',
+    'Filename includes the table id and generation date'
+  );
+}
+
+function testCsvNumbersAreRaw(): void {
+  section('CSV NUMERIC OUTPUT');
+
+  const table = buildAccumulationTable('summary', testAccounts, accumulation, meta);
+  const { body } = splitCsv(toCsv(table));
+  const firstRow = body[0].split(',');
+
+  assert(!body[0].includes('$'), 'Money values carry no currency symbol');
+  assert(
+    !body[0].includes('"'),
+    'Numeric rows need no quoting — no formatted values sneak in'
+  );
+  assert(
+    firstRow.every(field => field === '' || Number.isFinite(Number(field))),
+    'Every field in a data row parses as a number (spreadsheets treat them as numeric)'
+  );
+  assertEqual(firstRow[0], '35', 'First row is the current age');
+  assertApprox(
+    Number(firstRow[2]),
+    190000,
+    1,
+    'Year 0 total balance matches the starting balances'
+  );
+  assertEqual(firstRow[4], '', 'Year 0 growth is blank rather than a bogus zero');
+}
+
+function testRealColumnsMatchNominal(): void {
+  section('REAL COLUMNS');
+
+  const table = buildAccumulationTable('summary', testAccounts, accumulation, meta);
+
+  const lastRow = table.rows[table.rows.length - 1];
+  const years = (lastRow.age as number) - testProfile.currentAge;
+  const expectedFactor = inflationFactor(years, testAssumptions.inflationRate);
+
+  assertApprox(
+    lastRow.inflationFactor as number,
+    expectedFactor,
+    0.0001,
+    'Inflation Factor column equals (1 + i)^(age - current age)'
+  );
+  assertApprox(
+    (lastRow.totalBalance as number) / (lastRow.inflationFactor as number),
+    lastRow.totalBalanceReal as number,
+    0.01,
+    'Nominal divided by the inflation factor equals the Real column'
+  );
+  assert(
+    (lastRow.totalBalanceReal as number) < (lastRow.totalBalance as number),
+    'Real balance is smaller than nominal in a positive-inflation world'
+  );
+
+  const firstRow = table.rows[0];
+  assertEqual(firstRow.inflationFactor, 1, 'Current year has an inflation factor of 1');
+  assertEqual(
+    firstRow.totalBalance,
+    firstRow.totalBalanceReal,
+    'Nominal and real agree in the base year'
+  );
+}
+
+function testTableCoverage(): void {
+  section('TABLE BUILDERS');
+
+  const accumulationIds = ['summary', 'balances', 'contributions'] as const;
+  accumulationIds.forEach(id => {
+    const table = buildAccumulationTable(id, testAccounts, accumulation, meta);
+    assert(table.rows.length > 0, `Accumulation "${id}" table has rows`);
+    assert(table.columns.length > 0, `Accumulation "${id}" table has columns`);
+    const csv = toCsv(table);
+    const { header, body } = splitCsv(csv);
+    assertEqual(
+      header.split(',').length >= table.columns.length,
+      true,
+      `Accumulation "${id}" header covers every column`
+    );
+    assertEqual(
+      body.length,
+      table.rows.length + (table.footer ? 1 : 0),
+      `Accumulation "${id}" writes every row (plus footer when present)`
+    );
+  });
+
+  const withdrawalIds = ['income', 'withdrawals', 'balances', 'taxes', 'incomeStreams'] as const;
+  withdrawalIds.forEach(id => {
+    const table = buildWithdrawalTable(id, testAccounts, retirement, testIncomeStreams, meta);
+    assert(table.rows.length > 0, `Retirement "${id}" table has rows`);
+    const { body } = splitCsv(toCsv(table));
+    assertEqual(
+      body.length,
+      table.rows.length + (table.footer ? 1 : 0),
+      `Retirement "${id}" writes every row (plus footer when present)`
+    );
+  });
+}
+
+function testFooterTotals(): void {
+  section('FOOTER TOTALS');
+
+  const taxTable = buildWithdrawalTable('taxes', testAccounts, retirement, testIncomeStreams, meta);
+  assert(!!taxTable.footer, 'Tax table has a lifetime totals footer');
+
+  const summedTax = taxTable.rows.reduce((sum, row) => sum + (row.totalTax as number), 0);
+  assertApprox(
+    taxTable.footer!.totalTax as number,
+    summedTax,
+    1,
+    'Footer total tax equals the sum of the yearly rows'
+  );
+  assertApprox(
+    taxTable.footer!.totalTax as number,
+    retirement.lifetimeTaxesPaid,
+    1,
+    'Footer total tax matches the engine lifetime figure'
+  );
+
+  const contributionsTable = buildAccumulationTable(
+    'contributions',
+    testAccounts,
+    accumulation,
+    meta
+  );
+  const summedContributions = contributionsTable.rows.reduce(
+    (sum, row) => sum + (row.total as number),
+    0
+  );
+  assertApprox(
+    contributionsTable.footer!.total as number,
+    summedContributions,
+    1,
+    'Contributions footer equals the sum of the yearly totals'
+  );
+}
+
+function testEmployerMatchColumns(): void {
+  section('EMPLOYER MATCH COLUMNS');
+
+  const table = buildAccumulationTable('contributions', testAccounts, accumulation, meta);
+  const labels = table.columns.map(column => column.label);
+
+  assert(
+    labels.includes('Company 401(k) (Employer Match)'),
+    'Matching accounts get a dedicated employer match column'
+  );
+  assert(
+    !labels.includes('Roth IRA (Employer Match)'),
+    'Non-matching accounts get no match column'
+  );
+
+  // Match is capped at the configured limit.
+  const lastRow = table.rows[table.rows.length - 1];
+  assert(
+    (lastRow['acc-401k:match'] as number) <= 3000,
+    'Employer match respects the configured dollar limit'
+  );
+
+  // Canadian employer RRSPs match too — this used to be missed by the table.
+  const caConfig = getCountryConfig('CA');
+  const caProfile: Profile = { ...testProfile, country: 'CA', region: 'ON' };
+  const caAccounts: Account[] = [
+    {
+      id: 'acc-rrsp',
+      name: 'Employer RRSP',
+      type: 'employer_rrsp',
+      balance: 150000,
+      annualContribution: 15000,
+      contributionGrowthRate: 0.03,
+      returnRate: 0.07,
+      employerMatchPercent: 0.5,
+      employerMatchLimit: 3000,
+      withdrawalRules: { startAge: 65 },
+    },
+  ];
+  const caAccumulation = calculateAccumulation(caAccounts, caProfile, caConfig);
+  const caMeta = buildExportMeta(caProfile, testAssumptions, 'CA', FIXED_DATE);
+  const caTable = buildAccumulationTable('contributions', caAccounts, caAccumulation, caMeta);
+
+  assert(
+    caTable.columns.some(column => column.label === 'Employer RRSP (Employer Match)'),
+    'Employer RRSP match is reported, matching the projection engine'
+  );
+  assertApprox(
+    caTable.rows[0]['acc-rrsp:match'] as number,
+    3000,
+    0.01,
+    'Employer RRSP match is capped at the limit (50% of $15k > $3k)'
+  );
+}
+
+function testRegionalTaxLabel(): void {
+  section('COUNTRY-AWARE LABELS');
+
+  const usTable = buildWithdrawalTable('taxes', testAccounts, retirement, testIncomeStreams, meta);
+  assert(
+    usTable.columns.some(column => column.label === 'State Tax'),
+    'US tax table labels the regional column "State Tax"'
+  );
+
+  const caMeta = buildExportMeta(
+    { ...testProfile, country: 'CA', region: 'ON' },
+    testAssumptions,
+    'CA',
+    FIXED_DATE
+  );
+  const caTable = buildWithdrawalTable(
+    'taxes',
+    testAccounts,
+    retirement,
+    testIncomeStreams,
+    caMeta
+  );
+  assert(
+    caTable.columns.some(column => column.label === 'Provincial Tax'),
+    'Canadian tax table labels the regional column "Provincial Tax"'
+  );
+  assertEqual(caMeta.currency, 'CAD', 'Canadian exports are denominated in CAD');
+}
+
+// =============================================================================
+// SCENARIO SAVE / LOAD
+// =============================================================================
+
+function testScenarioRoundTrip(): void {
+  section('SCENARIO ROUND TRIP');
+
+  const scenario = buildScenario(
+    {
+      country: 'US',
+      profile: testProfile,
+      accounts: testAccounts,
+      incomeStreams: testIncomeStreams,
+      assumptions: testAssumptions,
+    },
+    FIXED_DATE
+  );
+
+  assertEqual(scenario.app, 'retirement-planner', 'Scenario is stamped with the app id');
+  assertEqual(
+    scenario.schemaVersion,
+    SCENARIO_SCHEMA_VERSION,
+    'Scenario carries the current schema version'
+  );
+  assertEqual(
+    scenarioFilename(FIXED_DATE),
+    'retirement-plan-2026-07-29.json',
+    'Scenario filename is dated'
+  );
+
+  const result = parseScenario(JSON.stringify(scenario));
+  if (!result.ok) {
+    assert(false, `Round trip parses cleanly (error: ${result.error})`);
+    return;
+  }
+
+  assert(true, 'Round trip parses cleanly');
+  assertEqual(
+    JSON.stringify(result.scenario.accounts),
+    JSON.stringify(testAccounts),
+    'Accounts survive the round trip unchanged'
+  );
+  assertEqual(
+    JSON.stringify(result.scenario.assumptions),
+    JSON.stringify(testAssumptions),
+    'Assumptions survive the round trip unchanged'
+  );
+  assertEqual(
+    JSON.stringify(result.scenario.incomeStreams),
+    JSON.stringify(testIncomeStreams),
+    'Income streams survive the round trip unchanged'
+  );
+  assertEqual(
+    result.scenario.profile.currentAge,
+    testProfile.currentAge,
+    'Profile survives the round trip'
+  );
+
+  // Projections from the reloaded scenario must match the original.
+  const reloaded = calculateAccumulation(result.scenario.accounts, result.scenario.profile, usConfig);
+  assertApprox(
+    reloaded.totalAtRetirement,
+    accumulation.totalAtRetirement,
+    0.01,
+    'Reloaded scenario reproduces the same projection'
+  );
+}
+
+function testScenarioDropsUnknownFields(): void {
+  section('SCENARIO SANITIZATION');
+
+  const withJunk = {
+    app: 'retirement-planner',
+    schemaVersion: 1,
+    exportedAt: FIXED_DATE.toISOString(),
+    country: 'US',
+    profile: { ...testProfile, injected: 'nope' },
+    accounts: [{ ...testAccounts[0], injected: 'nope' }],
+    incomeStreams: [],
+    assumptions: testAssumptions,
+    somethingElse: { deeply: 'nested' },
+  };
+
+  const result = parseScenario(JSON.stringify(withJunk));
+  if (!result.ok) {
+    assert(false, `Junk-bearing file still parses (error: ${result.error})`);
+    return;
+  }
+
+  assert(
+    !('injected' in result.scenario.accounts[0]),
+    'Unknown account fields are dropped rather than written to storage'
+  );
+  assert(
+    !('injected' in result.scenario.profile),
+    'Unknown profile fields are dropped rather than written to storage'
+  );
+  assert(
+    !('somethingElse' in result.scenario),
+    'Unknown top-level fields are dropped'
+  );
+}
+
+function testScenarioValidation(): void {
+  section('SCENARIO VALIDATION');
+
+  const base = {
+    app: 'retirement-planner',
+    schemaVersion: 1,
+    exportedAt: FIXED_DATE.toISOString(),
+    country: 'US',
+    profile: testProfile,
+    accounts: testAccounts,
+    incomeStreams: testIncomeStreams,
+    assumptions: testAssumptions,
+  };
+
+  const expectFailure = (payload: unknown, description: string, expectedFragment?: string) => {
+    const text = typeof payload === 'string' ? payload : JSON.stringify(payload);
+    const result = parseScenario(text);
+    if (result.ok) {
+      assert(false, `${description} is rejected`);
+      return;
+    }
+    if (expectedFragment && !result.error.toLowerCase().includes(expectedFragment.toLowerCase())) {
+      assert(false, `${description} is rejected with a useful message (got: "${result.error}")`);
+      return;
+    }
+    assert(true, `${description} is rejected — "${result.error}"`);
+  };
+
+  expectFailure('not json at all', 'Malformed JSON', 'valid JSON');
+  expectFailure('[1,2,3]', 'A JSON array');
+  expectFailure({ ...base, app: 'some-other-app' }, 'A file from another app', 'Retirement Planner');
+  expectFailure(
+    { ...base, schemaVersion: SCENARIO_SCHEMA_VERSION + 1 },
+    'A file from a newer version',
+    'newer version'
+  );
+  expectFailure({ ...base, schemaVersion: 0 }, 'An unrecognized schema version');
+  expectFailure({ ...base, country: 'UK' }, 'An unsupported country', 'country');
+  expectFailure({ ...base, profile: undefined }, 'A missing profile', 'profile');
+  expectFailure({ ...base, assumptions: undefined }, 'Missing assumptions', 'assumptions');
+  expectFailure({ ...base, accounts: 'lots' }, 'A non-list accounts field', 'accounts');
+  expectFailure(
+    { ...base, accounts: [{ ...testAccounts[0], type: 'crypto_wallet' }] },
+    'An unrecognized account type',
+    'account type'
+  );
+  expectFailure(
+    { ...base, accounts: [{ ...testAccounts[0], balance: 'a lot' }] },
+    'A non-numeric balance',
+    'balance'
+  );
+  expectFailure(
+    { ...base, accounts: [{ ...testAccounts[0], balance: null }] },
+    'A null balance'
+  );
+  expectFailure(
+    { ...base, profile: { ...testProfile, currentAge: 'thirty-five' } },
+    'A non-numeric age',
+    'currentAge'
+  );
+  expectFailure(
+    { ...base, profile: { ...testProfile, filingStatus: 'its_complicated' } },
+    'An invalid filing status',
+    'filingStatus'
+  );
+  expectFailure(
+    { ...base, incomeStreams: [{ ...testIncomeStreams[0], taxTreatment: 'lottery' }] },
+    'An unrecognized income tax treatment',
+    'taxTreatment'
+  );
+  expectFailure(
+    { ...base, assumptions: { ...testAssumptions, inflationRate: Infinity } },
+    'A non-finite assumption',
+    'inflationRate'
+  );
+
+  // An older-but-supported version is accepted.
+  const okResult = parseScenario(JSON.stringify({ ...base, schemaVersion: 1 }));
+  assert(okResult.ok, 'A file at the current schema version is accepted');
+
+  // Accounts saved before withdrawal rules existed still load.
+  const legacyAccount = { ...testAccounts[0] };
+  delete (legacyAccount as Partial<Account>).withdrawalRules;
+  const legacyResult = parseScenario(JSON.stringify({ ...base, accounts: [legacyAccount] }));
+  if (legacyResult.ok) {
+    assertEqual(
+      legacyResult.scenario.accounts[0].withdrawalRules,
+      undefined,
+      'Accounts without withdrawal rules load (the app normalizes them on read)'
+    );
+  } else {
+    assert(false, `Legacy accounts load (error: ${legacyResult.error})`);
+  }
+}
+
+function testScenarioCountrySwitch(): void {
+  section('SCENARIO COUNTRY HANDLING');
+
+  const caScenario = {
+    app: 'retirement-planner',
+    schemaVersion: 1,
+    exportedAt: FIXED_DATE.toISOString(),
+    country: 'CA',
+    // A profile whose stored country disagrees with the file's country.
+    profile: { ...testProfile, country: 'US' },
+    accounts: [
+      {
+        id: 'acc-tfsa',
+        name: 'TFSA',
+        type: 'tfsa',
+        balance: 40000,
+        annualContribution: 7000,
+        contributionGrowthRate: 0,
+        returnRate: 0.07,
+      },
+    ],
+    incomeStreams: [],
+    assumptions: testAssumptions,
+  };
+
+  const result = parseScenario(JSON.stringify(caScenario));
+  if (!result.ok) {
+    assert(false, `Canadian scenario parses (error: ${result.error})`);
+    return;
+  }
+
+  assertEqual(result.scenario.country, 'CA', 'File-level country is preserved');
+  assertEqual(
+    result.scenario.profile.country,
+    'CA',
+    'Profile country is forced to match the file, so account types stay valid'
+  );
+}
+
+// =============================================================================
+// RUN
+// =============================================================================
+
+function runAllTests(): void {
+  console.log('\n' + '█'.repeat(60));
+  console.log('EXPORT FEATURE TEST SUITE');
+  console.log('█'.repeat(60));
+
+  testRealDollars();
+  testCsvEscaping();
+  testCsvStructure();
+  testCsvNumbersAreRaw();
+  testRealColumnsMatchNominal();
+  testTableCoverage();
+  testFooterTotals();
+  testEmployerMatchColumns();
+  testRegionalTaxLabel();
+  testScenarioRoundTrip();
+  testScenarioDropsUnknownFields();
+  testScenarioValidation();
+  testScenarioCountrySwitch();
+
+  console.log('\n' + '='.repeat(60));
+  console.log('TEST SUMMARY');
+  console.log('='.repeat(60));
+  console.log(`  ✓ Passed: ${passedTests}`);
+  console.log(`  ✗ Failed: ${failedTests}`);
+  console.log(`  Total: ${passedTests + failedTests}`);
+  console.log('='.repeat(60) + '\n');
+
+  if (failedTests > 0) {
+    process.exit(1);
+  }
+}
+
+runAllTests();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,11 +24,60 @@ export type CAAccountType =
 // Combined account type (union of all countries)
 export type AccountType = USAccountType | CAAccountType;
 
+/**
+ * Runtime list of every account type, for validating data that arrives from
+ * outside the app (imported scenario files). The `AssertAllAccountTypes` alias
+ * below fails to compile if a member of the union is missing here.
+ */
+export const ALL_ACCOUNT_TYPES = [
+  'traditional_401k',
+  'roth_401k',
+  'traditional_ira',
+  'roth_ira',
+  'taxable',
+  'hsa',
+  'rrsp',
+  'tfsa',
+  'rrif',
+  'lira',
+  'lif',
+  'fhsa',
+  'non_registered',
+  'employer_rrsp',
+] as const satisfies readonly AccountType[];
+
+type AssertNever<T extends never> = T;
+export type AssertAllAccountTypes = AssertNever<
+  Exclude<AccountType, (typeof ALL_ACCOUNT_TYPES)[number]>
+>;
+
+export function isAccountType(value: unknown): value is AccountType {
+  return typeof value === 'string' && (ALL_ACCOUNT_TYPES as readonly string[]).includes(value);
+}
+
 export type FilingStatus = 'single' | 'married_filing_jointly';
 
 export type TaxTreatment = 'pretax' | 'roth' | 'taxable' | 'hsa';
 
 export type IncomeTaxTreatment = 'social_security' | 'fully_taxable' | 'other_income' | 'tax_free';
+
+export const ALL_INCOME_TAX_TREATMENTS = [
+  'social_security',
+  'fully_taxable',
+  'other_income',
+  'tax_free',
+] as const satisfies readonly IncomeTaxTreatment[];
+
+export type AssertAllIncomeTaxTreatments = AssertNever<
+  Exclude<IncomeTaxTreatment, (typeof ALL_INCOME_TAX_TREATMENTS)[number]>
+>;
+
+export function isIncomeTaxTreatment(value: unknown): value is IncomeTaxTreatment {
+  return (
+    typeof value === 'string' &&
+    (ALL_INCOME_TAX_TREATMENTS as readonly string[]).includes(value)
+  );
+}
 
 export interface IncomeStream {
   id: string;

--- a/src/utils/export/csv.ts
+++ b/src/utils/export/csv.ts
@@ -1,0 +1,108 @@
+import type { ExportCell, ExportMeta, ExportTable } from './types';
+
+const CRLF = '\r\n';
+
+/** Fields containing these need quoting per RFC 4180. */
+const NEEDS_QUOTES = /[",\r\n]/;
+
+/**
+ * Leading characters that make a spreadsheet treat a cell as a formula.
+ * Account and income-stream names are user-supplied (and can arrive from an
+ * imported scenario file), so they get a leading apostrophe to neutralize them.
+ * '-' is deliberately excluded: it would mangle ordinary names far more often
+ * than it would prevent anything, and negative numbers are written unquoted.
+ */
+const FORMULA_PREFIX = /^[=+@\t\r]/;
+
+function escapeField(value: ExportCell | undefined): string {
+  if (value === null || value === undefined) return '';
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return '';
+    // Trim float noise without losing cents.
+    return String(Math.round(value * 100) / 100);
+  }
+
+  let text = value;
+  if (FORMULA_PREFIX.test(text)) {
+    text = `'${text}`;
+  }
+  if (NEEDS_QUOTES.test(text) || text !== text.trim()) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+  return text;
+}
+
+function row(fields: (ExportCell | undefined)[]): string {
+  return fields.map(escapeField).join(',');
+}
+
+/**
+ * Metadata emitted *after* the data, separated by a blank line, so the header
+ * row stays the first line of the file and spreadsheets auto-detect it.
+ */
+function metaRows(title: string, meta: ExportMeta): string[] {
+  const { profile, assumptions } = meta;
+  const pct = (value: number) => `${(value * 100).toFixed(2)}%`;
+
+  return [
+    row(['# Retirement Planner export']),
+    row(['# Table', title]),
+    row(['# Generated', meta.generatedAt.toISOString().slice(0, 10)]),
+    row(['# Country', meta.country]),
+    row(['# Currency', meta.currency]),
+    row([
+      '# Dollars',
+      'Nominal (future) dollars, except columns labelled "Real"',
+    ]),
+    row([
+      '# Real dollars',
+      `Nominal divided by the Inflation Factor column; expressed in ${meta.baseYear} dollars`,
+    ]),
+    row([
+      '# Inflation factor',
+      `(1 + inflation rate) ^ (age - current age)`,
+    ]),
+    row(['# Inflation rate', pct(assumptions.inflationRate)]),
+    row(['# Safe withdrawal rate', pct(assumptions.safeWithdrawalRate)]),
+    row(['# Retirement return rate', pct(assumptions.retirementReturnRate)]),
+    row(['# Current age', profile.currentAge]),
+    row(['# Retirement age', profile.retirementAge]),
+    row(['# Life expectancy', profile.lifeExpectancy]),
+    row([
+      '# Note',
+      'Tax brackets are not indexed to inflation in this model, so nominal tax figures include bracket creep. Deflating them gives the present value of the dollars paid, but the modelled burden is still higher than it would be under indexed brackets.',
+    ]),
+    row([
+      '# Disclaimer',
+      'Estimates only. Consult a financial advisor for personalized advice.',
+    ]),
+  ];
+}
+
+/** Byte-order mark — without it Excel misreads UTF-8 accents in account names. */
+const BOM = '\uFEFF';
+
+/** Serialize a table to RFC 4180 CSV with a UTF-8 BOM (so Excel reads accents). */
+export function toCsv(table: ExportTable): string {
+  const keys = table.columns.map(column => column.key);
+
+  const lines = [
+    row(table.columns.map(column => column.label)),
+    ...table.rows.map(dataRow => row(keys.map(key => dataRow[key]))),
+  ];
+
+  if (table.footer) {
+    lines.push(row(keys.map(key => table.footer![key])));
+  }
+
+  lines.push('', ...metaRows(table.title, table.meta));
+
+  return `${BOM}${lines.join(CRLF)}${CRLF}`;
+}
+
+/** e.g. `retirement-planner-accumulation-summary-2026-07-29.csv` */
+export function csvFilename(table: ExportTable): string {
+  const date = table.meta.generatedAt.toISOString().slice(0, 10);
+  return `retirement-planner-${table.id}-${date}.csv`;
+}

--- a/src/utils/export/download.ts
+++ b/src/utils/export/download.ts
@@ -1,0 +1,24 @@
+/** Trigger a browser download of in-memory text content. */
+export function downloadText(filename: string, contents: string, mimeType: string): void {
+  const blob = new Blob([contents], { type: `${mimeType};charset=utf-8` });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.rel = 'noopener';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  // Safari needs the URL to outlive the click.
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+export function downloadCsv(filename: string, contents: string): void {
+  downloadText(filename, contents, 'text/csv');
+}
+
+export function downloadJson(filename: string, contents: string): void {
+  downloadText(filename, contents, 'application/json');
+}

--- a/src/utils/export/format.ts
+++ b/src/utils/export/format.ts
@@ -1,0 +1,29 @@
+import type { ExportCell, ExportColumnType } from './types';
+
+/** Human-readable rendering of an export cell — used by the print report. */
+export function formatCell(
+  value: ExportCell | undefined,
+  type: ExportColumnType,
+  currency: string
+): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'string') return value;
+  if (!Number.isFinite(value)) return '—';
+
+  switch (type) {
+    case 'currency':
+      return new Intl.NumberFormat(currency === 'CAD' ? 'en-CA' : 'en-US', {
+        style: 'currency',
+        currency,
+        maximumFractionDigits: 0,
+      }).format(value);
+    case 'percent':
+      return `${(value * 100).toFixed(1)}%`;
+    case 'factor':
+      return value.toFixed(3);
+    case 'number':
+    case 'text':
+    default:
+      return String(value);
+  }
+}

--- a/src/utils/export/index.ts
+++ b/src/utils/export/index.ts
@@ -1,0 +1,7 @@
+export * from './types';
+export * from './csv';
+export * from './download';
+export * from './format';
+export * from './realDollars';
+export * from './scenario';
+export * from './tables';

--- a/src/utils/export/realDollars.ts
+++ b/src/utils/export/realDollars.ts
@@ -1,0 +1,30 @@
+/**
+ * Nominal <-> real (today's dollars) conversion.
+ *
+ * Every number produced by the projection engine is *nominal*: the actual
+ * dollars changing hands in that future year. `projections.ts` compounds
+ * balances at each account's return rate, and `withdrawals.ts` inflates the
+ * spending target, benefits, and income streams year over year. Nothing is
+ * deflated back to present value.
+ *
+ * Anything that presents "today's dollars" must divide by the inflation factor
+ * for that year — see SummaryCards and the CSV/print exports.
+ */
+
+/**
+ * Cumulative inflation multiplier between today and `yearsFromNow`.
+ * Divide a nominal amount by this to get today's-dollar purchasing power.
+ */
+export function inflationFactor(yearsFromNow: number, inflationRate: number): number {
+  if (yearsFromNow <= 0) return 1;
+  return Math.pow(1 + inflationRate, yearsFromNow);
+}
+
+/** Convert a future nominal amount to its present (today's-dollar) value. */
+export function presentValue(
+  nominalAmount: number,
+  yearsFromNow: number,
+  inflationRate: number
+): number {
+  return nominalAmount / inflationFactor(yearsFromNow, inflationRate);
+}

--- a/src/utils/export/scenario.ts
+++ b/src/utils/export/scenario.ts
@@ -1,0 +1,249 @@
+import {
+  Account,
+  AccountType,
+  Assumptions,
+  FilingStatus,
+  IncomeStream,
+  Profile,
+  isAccountType,
+  isIncomeTaxTreatment,
+} from '../../types';
+import type { CountryCode } from '../../countries';
+
+export const SCENARIO_APP_ID = 'retirement-planner';
+export const SCENARIO_SCHEMA_VERSION = 1;
+
+export interface ScenarioFile {
+  app: typeof SCENARIO_APP_ID;
+  schemaVersion: number;
+  exportedAt: string;
+  country: CountryCode;
+  profile: Profile;
+  accounts: Account[];
+  incomeStreams: IncomeStream[];
+  assumptions: Assumptions;
+}
+
+export type ParseResult =
+  | { ok: true; scenario: ScenarioFile }
+  | { ok: false; error: string };
+
+interface ScenarioInput {
+  country: CountryCode;
+  profile: Profile;
+  accounts: Account[];
+  incomeStreams: IncomeStream[];
+  assumptions: Assumptions;
+}
+
+export function buildScenario(input: ScenarioInput, now: Date = new Date()): ScenarioFile {
+  return {
+    app: SCENARIO_APP_ID,
+    schemaVersion: SCENARIO_SCHEMA_VERSION,
+    exportedAt: now.toISOString(),
+    country: input.country,
+    profile: input.profile,
+    accounts: input.accounts,
+    incomeStreams: input.incomeStreams,
+    assumptions: input.assumptions,
+  };
+}
+
+export function scenarioFilename(now: Date = new Date()): string {
+  return `retirement-plan-${now.toISOString().slice(0, 10)}.json`;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+//
+// Files can be hand-edited or come from another machine, so every field is
+// checked and unknown fields are dropped rather than written into localStorage.
+// ---------------------------------------------------------------------------
+
+class ValidationError extends Error {}
+
+function fail(message: string): never {
+  throw new ValidationError(message);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function num(value: unknown, label: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    fail(`${label} must be a number.`);
+  }
+  return value;
+}
+
+function optionalNum(value: unknown, label: string): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  return num(value, label);
+}
+
+function str(value: unknown, label: string): string {
+  if (typeof value !== 'string') fail(`${label} must be text.`);
+  return value;
+}
+
+function parseProfile(value: unknown, country: CountryCode): Profile {
+  if (!isRecord(value)) fail('The file is missing its "profile" section.');
+
+  const filingStatus = value.filingStatus;
+  if (
+    filingStatus !== undefined &&
+    filingStatus !== 'single' &&
+    filingStatus !== 'married_filing_jointly'
+  ) {
+    fail('profile.filingStatus must be "single" or "married_filing_jointly".');
+  }
+
+  return {
+    country,
+    currentAge: num(value.currentAge, 'profile.currentAge'),
+    retirementAge: num(value.retirementAge, 'profile.retirementAge'),
+    lifeExpectancy: num(value.lifeExpectancy, 'profile.lifeExpectancy'),
+    region: str(value.region, 'profile.region'),
+    filingStatus: filingStatus as FilingStatus | undefined,
+    stateTaxRate: optionalNum(value.stateTaxRate, 'profile.stateTaxRate'),
+    socialSecurityBenefit: optionalNum(
+      value.socialSecurityBenefit,
+      'profile.socialSecurityBenefit'
+    ),
+    socialSecurityStartAge: optionalNum(
+      value.socialSecurityStartAge,
+      'profile.socialSecurityStartAge'
+    ),
+    secondaryBenefitStartAge: optionalNum(
+      value.secondaryBenefitStartAge,
+      'profile.secondaryBenefitStartAge'
+    ),
+    secondaryBenefitAmount: optionalNum(
+      value.secondaryBenefitAmount,
+      'profile.secondaryBenefitAmount'
+    ),
+  };
+}
+
+function parseAccount(value: unknown, index: number): Account {
+  if (!isRecord(value)) fail(`Account #${index + 1} is not valid.`);
+
+  const label = `accounts[${index}]`;
+  if (!isAccountType(value.type)) {
+    fail(`${label}.type is not a recognized account type ("${String(value.type)}").`);
+  }
+
+  const withdrawalRules = value.withdrawalRules;
+  let parsedRules: Account['withdrawalRules'];
+  if (withdrawalRules !== undefined && withdrawalRules !== null) {
+    if (!isRecord(withdrawalRules)) fail(`${label}.withdrawalRules is not valid.`);
+    parsedRules = {
+      startAge: num(withdrawalRules.startAge, `${label}.withdrawalRules.startAge`),
+    };
+  }
+
+  return {
+    id: str(value.id, `${label}.id`),
+    name: str(value.name, `${label}.name`),
+    type: value.type as AccountType,
+    balance: num(value.balance, `${label}.balance`),
+    annualContribution: num(value.annualContribution, `${label}.annualContribution`),
+    contributionGrowthRate: num(
+      value.contributionGrowthRate,
+      `${label}.contributionGrowthRate`
+    ),
+    returnRate: num(value.returnRate, `${label}.returnRate`),
+    employerMatchPercent: optionalNum(
+      value.employerMatchPercent,
+      `${label}.employerMatchPercent`
+    ),
+    employerMatchLimit: optionalNum(value.employerMatchLimit, `${label}.employerMatchLimit`),
+    withdrawalRules: parsedRules,
+  };
+}
+
+function parseIncomeStream(value: unknown, index: number): IncomeStream {
+  if (!isRecord(value)) fail(`Income stream #${index + 1} is not valid.`);
+
+  const label = `incomeStreams[${index}]`;
+  if (!isIncomeTaxTreatment(value.taxTreatment)) {
+    fail(`${label}.taxTreatment is not recognized ("${String(value.taxTreatment)}").`);
+  }
+
+  return {
+    id: str(value.id, `${label}.id`),
+    name: str(value.name, `${label}.name`),
+    monthlyAmount: num(value.monthlyAmount, `${label}.monthlyAmount`),
+    startAge: num(value.startAge, `${label}.startAge`),
+    endAge: optionalNum(value.endAge, `${label}.endAge`),
+    taxTreatment: value.taxTreatment,
+  };
+}
+
+function parseAssumptions(value: unknown): Assumptions {
+  if (!isRecord(value)) fail('The file is missing its "assumptions" section.');
+  return {
+    inflationRate: num(value.inflationRate, 'assumptions.inflationRate'),
+    safeWithdrawalRate: num(value.safeWithdrawalRate, 'assumptions.safeWithdrawalRate'),
+    retirementReturnRate: num(
+      value.retirementReturnRate,
+      'assumptions.retirementReturnRate'
+    ),
+  };
+}
+
+export function parseScenario(text: string): ParseResult {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    return { ok: false, error: "That file isn't valid JSON." };
+  }
+
+  try {
+    if (!isRecord(raw)) fail('The file does not contain a saved plan.');
+
+    if (raw.app !== SCENARIO_APP_ID) {
+      fail("That file wasn't saved by Retirement Planner.");
+    }
+
+    const schemaVersion = num(raw.schemaVersion, 'schemaVersion');
+    if (schemaVersion > SCENARIO_SCHEMA_VERSION) {
+      fail(
+        `That file was saved by a newer version of Retirement Planner (format v${schemaVersion}; this version reads up to v${SCENARIO_SCHEMA_VERSION}).`
+      );
+    }
+    if (schemaVersion < 1) {
+      fail(`Unrecognized file format version (v${schemaVersion}).`);
+    }
+
+    if (raw.country !== 'US' && raw.country !== 'CA') {
+      fail('The file does not specify a supported country (expected "US" or "CA").');
+    }
+    const country: CountryCode = raw.country;
+
+    if (!Array.isArray(raw.accounts)) fail('The file is missing its "accounts" list.');
+    if (!Array.isArray(raw.incomeStreams)) {
+      fail('The file is missing its "incomeStreams" list.');
+    }
+
+    const scenario: ScenarioFile = {
+      app: SCENARIO_APP_ID,
+      schemaVersion,
+      exportedAt: typeof raw.exportedAt === 'string' ? raw.exportedAt : '',
+      country,
+      profile: parseProfile(raw.profile, country),
+      accounts: raw.accounts.map(parseAccount),
+      incomeStreams: raw.incomeStreams.map(parseIncomeStream),
+      assumptions: parseAssumptions(raw.assumptions),
+    };
+
+    return { ok: true, scenario };
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return { ok: false, error: error.message };
+    }
+    return { ok: false, error: 'That file could not be read as a saved plan.' };
+  }
+}

--- a/src/utils/export/tables.ts
+++ b/src/utils/export/tables.ts
@@ -1,0 +1,579 @@
+import {
+  Account,
+  AccumulationResult,
+  Assumptions,
+  IncomeStream,
+  Profile,
+  RetirementResult,
+  getAccountTypeLabel,
+  getIncomeTaxTreatmentLabel,
+} from '../../types';
+import type { CountryCode } from '../../countries';
+import { getEmployerMatch, supportsEmployerMatch } from '../projections';
+import { inflationFactor } from './realDollars';
+import type { ExportColumn, ExportMeta, ExportRow, ExportTable } from './types';
+
+export type AccumulationTableId = 'summary' | 'balances' | 'contributions';
+export type WithdrawalTableId =
+  | 'income'
+  | 'withdrawals'
+  | 'balances'
+  | 'taxes'
+  | 'incomeStreams';
+
+export function currencyForCountry(country: CountryCode): string {
+  return country === 'CA' ? 'CAD' : 'USD';
+}
+
+export function buildExportMeta(
+  profile: Profile,
+  assumptions: Assumptions,
+  country: CountryCode,
+  now: Date = new Date()
+): ExportMeta {
+  return {
+    generatedAt: now,
+    country,
+    currency: currencyForCountry(country),
+    baseYear: now.getFullYear(),
+    profile,
+    assumptions,
+  };
+}
+
+/** Column keys are derived from account/stream ids, which are UUIDs. */
+function accountColumns(accounts: Account[], suffix = ''): ExportColumn[] {
+  return accounts.map(account => ({
+    key: account.id,
+    label: `${account.name}${suffix}`,
+    type: 'currency' as const,
+  }));
+}
+
+const AGE_COLUMNS: ExportColumn[] = [
+  { key: 'age', label: 'Age', type: 'number' },
+  { key: 'year', label: 'Year', type: 'number' },
+];
+
+const FACTOR_COLUMN: ExportColumn = {
+  key: 'inflationFactor',
+  label: 'Inflation Factor',
+  type: 'factor',
+};
+
+// ---------------------------------------------------------------------------
+// Accumulation phase
+// ---------------------------------------------------------------------------
+
+export function buildAccumulationTable(
+  tableId: AccumulationTableId,
+  accounts: Account[],
+  result: AccumulationResult,
+  meta: ExportMeta
+): ExportTable {
+  const { inflationRate } = meta.assumptions;
+  const currentAge = meta.profile.currentAge;
+  const factorFor = (age: number) => inflationFactor(age - currentAge, inflationRate);
+
+  if (tableId === 'summary') {
+    const rows: ExportRow[] = result.yearlyBalances.map((yearData, index) => {
+      const previousBalance =
+        index > 0 ? result.yearlyBalances[index - 1].totalBalance : yearData.totalBalance;
+      const contributions = Object.values(yearData.contributions).reduce(
+        (sum, value) => sum + value,
+        0
+      );
+      const match = accounts.reduce(
+        (sum, account) =>
+          sum + getEmployerMatch(account, yearData.contributions[account.id] || 0),
+        0
+      );
+      const totalContributions = contributions + match;
+      const factor = factorFor(yearData.age);
+
+      return {
+        age: yearData.age,
+        year: yearData.year,
+        totalBalance: yearData.totalBalance,
+        totalBalanceReal: yearData.totalBalance / factor,
+        growth: index === 0 ? null : yearData.totalBalance - previousBalance,
+        totalContributions,
+        totalContributionsReal: totalContributions / factor,
+        inflationFactor: factor,
+      };
+    });
+
+    return {
+      id: 'accumulation-summary',
+      title: 'Accumulation — Summary',
+      columns: [
+        ...AGE_COLUMNS,
+        { key: 'totalBalance', label: 'Total Balance', type: 'currency' },
+        { key: 'totalBalanceReal', label: 'Total Balance (Real)', type: 'currency' },
+        { key: 'growth', label: 'Year Growth', type: 'currency' },
+        { key: 'totalContributions', label: 'Total Contributions', type: 'currency' },
+        {
+          key: 'totalContributionsReal',
+          label: 'Total Contributions (Real)',
+          type: 'currency',
+        },
+        FACTOR_COLUMN,
+      ],
+      rows,
+      meta,
+    };
+  }
+
+  if (tableId === 'balances') {
+    const rows: ExportRow[] = result.yearlyBalances.map(yearData => {
+      const row: ExportRow = {
+        age: yearData.age,
+        year: yearData.year,
+        total: yearData.totalBalance,
+        inflationFactor: factorFor(yearData.age),
+      };
+      accounts.forEach(account => {
+        row[account.id] = yearData.balances[account.id] || 0;
+      });
+      return row;
+    });
+
+    return {
+      id: 'accumulation-balances',
+      title: 'Accumulation — Balances by Account',
+      columns: [
+        ...AGE_COLUMNS,
+        ...accountColumns(accounts),
+        { key: 'total', label: 'Total', type: 'currency' },
+        FACTOR_COLUMN,
+      ],
+      rows,
+      meta,
+    };
+  }
+
+  // Contributions: employer match gets its own column so the CSV stays numeric.
+  const columns: ExportColumn[] = [
+    ...AGE_COLUMNS,
+    ...accounts.flatMap<ExportColumn>(account => {
+      const own: ExportColumn = {
+        key: account.id,
+        label: account.name,
+        type: 'currency',
+      };
+      return supportsEmployerMatch(account)
+        ? [
+            own,
+            {
+              key: `${account.id}:match`,
+              label: `${account.name} (Employer Match)`,
+              type: 'currency',
+            },
+          ]
+        : [own];
+    }),
+    { key: 'total', label: 'Total', type: 'currency' },
+    FACTOR_COLUMN,
+  ];
+
+  const rows: ExportRow[] = result.yearlyBalances.map(yearData => {
+    const row: ExportRow = {
+      age: yearData.age,
+      year: yearData.year,
+      inflationFactor: factorFor(yearData.age),
+    };
+    let total = 0;
+    accounts.forEach(account => {
+      const contribution = yearData.contributions[account.id] || 0;
+      const match = getEmployerMatch(account, contribution);
+      row[account.id] = contribution;
+      if (supportsEmployerMatch(account)) {
+        row[`${account.id}:match`] = match;
+      }
+      total += contribution + match;
+    });
+    row.total = total;
+    return row;
+  });
+
+  const footer: ExportRow = { age: 'Lifetime Total', year: null, inflationFactor: null };
+  let lifetimeTotal = 0;
+  accounts.forEach(account => {
+    const contributions = result.yearlyBalances.reduce(
+      (sum, yearData) => sum + (yearData.contributions[account.id] || 0),
+      0
+    );
+    const match = result.yearlyBalances.reduce(
+      (sum, yearData) =>
+        sum + getEmployerMatch(account, yearData.contributions[account.id] || 0),
+      0
+    );
+    footer[account.id] = contributions;
+    if (supportsEmployerMatch(account)) {
+      footer[`${account.id}:match`] = match;
+    }
+    lifetimeTotal += contributions + match;
+  });
+  footer.total = lifetimeTotal;
+
+  return {
+    id: 'accumulation-contributions',
+    title: 'Accumulation — Contributions',
+    columns,
+    rows,
+    footer,
+    meta,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Retirement phase
+// ---------------------------------------------------------------------------
+
+/**
+ * Allocate a year's total income-stream income back to individual streams,
+ * pro-rata by monthly amount. Mirrors the on-screen table: the engine returns
+ * only a combined figure per year.
+ */
+function streamShare(
+  stream: IncomeStream,
+  age: number,
+  totalStreamIncome: number,
+  incomeStreams: IncomeStream[]
+): number | null {
+  const isActive = age >= stream.startAge && (!stream.endAge || age <= stream.endAge);
+  if (!isActive) return null;
+
+  const activeMonthly = incomeStreams
+    .filter(other => age >= other.startAge && (!other.endAge || age <= other.endAge))
+    .reduce((sum, other) => sum + other.monthlyAmount, 0);
+
+  if (activeMonthly === 0) return null;
+  return totalStreamIncome * (stream.monthlyAmount / activeMonthly);
+}
+
+export function buildWithdrawalTable(
+  tableId: WithdrawalTableId,
+  accounts: Account[],
+  result: RetirementResult,
+  incomeStreams: IncomeStream[],
+  meta: ExportMeta
+): ExportTable {
+  const { inflationRate } = meta.assumptions;
+  const currentAge = meta.profile.currentAge;
+  const factorFor = (age: number) => inflationFactor(age - currentAge, inflationRate);
+  const regionalTaxLabel = meta.country === 'CA' ? 'Provincial Tax' : 'State Tax';
+  const years = result.yearlyWithdrawals;
+
+  if (tableId === 'income') {
+    const rows: ExportRow[] = years.map(yearData => {
+      const factor = factorFor(yearData.age);
+      return {
+        age: yearData.age,
+        year: yearData.year,
+        targetSpending: yearData.targetSpending,
+        targetSpendingReal: yearData.targetSpending / factor,
+        totalWithdrawal: yearData.totalWithdrawal,
+        retirementIncome: yearData.governmentBenefitIncome + yearData.incomeStreamIncome,
+        grossIncome: yearData.grossIncome,
+        totalTax: yearData.totalTax,
+        afterTaxIncome: yearData.afterTaxIncome,
+        afterTaxIncomeReal: yearData.afterTaxIncome / factor,
+        inflationFactor: factor,
+      };
+    });
+
+    const footer: ExportRow = {
+      age: 'Lifetime Total',
+      year: null,
+      targetSpending: null,
+      targetSpendingReal: null,
+      totalWithdrawal: years.reduce((sum, y) => sum + y.totalWithdrawal, 0),
+      retirementIncome: years.reduce(
+        (sum, y) => sum + y.governmentBenefitIncome + y.incomeStreamIncome,
+        0
+      ),
+      grossIncome: years.reduce((sum, y) => sum + y.grossIncome, 0),
+      totalTax: result.lifetimeTaxesPaid,
+      afterTaxIncome: years.reduce((sum, y) => sum + y.afterTaxIncome, 0),
+      afterTaxIncomeReal: years.reduce(
+        (sum, y) => sum + y.afterTaxIncome / factorFor(y.age),
+        0
+      ),
+      inflationFactor: null,
+    };
+
+    return {
+      id: 'retirement-income',
+      title: 'Retirement — Income & Spending',
+      columns: [
+        ...AGE_COLUMNS,
+        { key: 'targetSpending', label: 'Target Spending', type: 'currency' },
+        { key: 'targetSpendingReal', label: 'Target Spending (Real)', type: 'currency' },
+        { key: 'totalWithdrawal', label: 'Withdrawals', type: 'currency' },
+        { key: 'retirementIncome', label: 'Retirement Income', type: 'currency' },
+        { key: 'grossIncome', label: 'Gross Income', type: 'currency' },
+        { key: 'totalTax', label: 'Total Taxes', type: 'currency' },
+        { key: 'afterTaxIncome', label: 'After-Tax Income', type: 'currency' },
+        { key: 'afterTaxIncomeReal', label: 'After-Tax Income (Real)', type: 'currency' },
+        FACTOR_COLUMN,
+      ],
+      rows,
+      footer,
+      meta,
+    };
+  }
+
+  if (tableId === 'withdrawals') {
+    const rows: ExportRow[] = years.map(yearData => {
+      const row: ExportRow = {
+        age: yearData.age,
+        year: yearData.year,
+        rmd: yearData.rmdAmount,
+        total: yearData.totalWithdrawal,
+        penalties: yearData.totalPenalties,
+        inflationFactor: factorFor(yearData.age),
+      };
+      accounts.forEach(account => {
+        row[account.id] = yearData.withdrawals[account.id] || 0;
+      });
+      return row;
+    });
+
+    return {
+      id: 'retirement-withdrawals',
+      title: 'Retirement — Withdrawals by Account',
+      columns: [
+        ...AGE_COLUMNS,
+        { key: 'rmd', label: 'RMD', type: 'currency' },
+        ...accountColumns(accounts),
+        { key: 'total', label: 'Total', type: 'currency' },
+        { key: 'penalties', label: 'Early Withdrawal Penalties', type: 'currency' },
+        FACTOR_COLUMN,
+      ],
+      rows,
+      meta,
+    };
+  }
+
+  if (tableId === 'balances') {
+    const rows: ExportRow[] = years.map(yearData => {
+      const factor = factorFor(yearData.age);
+      const row: ExportRow = {
+        age: yearData.age,
+        year: yearData.year,
+        total: yearData.totalRemainingBalance,
+        totalReal: yearData.totalRemainingBalance / factor,
+        inflationFactor: factor,
+      };
+      accounts.forEach(account => {
+        row[account.id] = yearData.remainingBalances[account.id] || 0;
+      });
+      return row;
+    });
+
+    return {
+      id: 'retirement-balances',
+      title: 'Retirement — Remaining Balances',
+      columns: [
+        ...AGE_COLUMNS,
+        ...accountColumns(accounts),
+        { key: 'total', label: 'Total', type: 'currency' },
+        { key: 'totalReal', label: 'Total (Real)', type: 'currency' },
+        FACTOR_COLUMN,
+      ],
+      rows,
+      meta,
+    };
+  }
+
+  if (tableId === 'taxes') {
+    const rows: ExportRow[] = years.map(yearData => {
+      const factor = factorFor(yearData.age);
+      return {
+        age: yearData.age,
+        year: yearData.year,
+        grossIncome: yearData.grossIncome,
+        federalTax: yearData.federalTax,
+        stateTax: yearData.stateTax,
+        penalties: yearData.totalPenalties,
+        totalTax: yearData.totalTax,
+        totalTaxReal: yearData.totalTax / factor,
+        effectiveRate:
+          yearData.grossIncome > 0 ? yearData.totalTax / yearData.grossIncome : 0,
+        inflationFactor: factor,
+      };
+    });
+
+    const lifetimeGross = years.reduce((sum, y) => sum + y.grossIncome, 0);
+    const footer: ExportRow = {
+      age: 'Lifetime Total',
+      year: null,
+      grossIncome: lifetimeGross,
+      federalTax: years.reduce((sum, y) => sum + y.federalTax, 0),
+      stateTax: years.reduce((sum, y) => sum + y.stateTax, 0),
+      penalties: years.reduce((sum, y) => sum + y.totalPenalties, 0),
+      totalTax: result.lifetimeTaxesPaid,
+      totalTaxReal: years.reduce((sum, y) => sum + y.totalTax / factorFor(y.age), 0),
+      effectiveRate: lifetimeGross > 0 ? result.lifetimeTaxesPaid / lifetimeGross : 0,
+      inflationFactor: null,
+    };
+
+    return {
+      id: 'retirement-taxes',
+      title: 'Retirement — Tax Details',
+      columns: [
+        ...AGE_COLUMNS,
+        { key: 'grossIncome', label: 'Gross Income', type: 'currency' },
+        { key: 'federalTax', label: 'Federal Tax', type: 'currency' },
+        { key: 'stateTax', label: regionalTaxLabel, type: 'currency' },
+        { key: 'penalties', label: 'Penalties', type: 'currency' },
+        { key: 'totalTax', label: 'Total Tax', type: 'currency' },
+        { key: 'totalTaxReal', label: 'Total Tax (Real)', type: 'currency' },
+        { key: 'effectiveRate', label: 'Effective Rate', type: 'percent' },
+        FACTOR_COLUMN,
+      ],
+      rows,
+      footer,
+      meta,
+    };
+  }
+
+  // Income streams
+  const hasGovernmentBenefits = years.some(y => y.governmentBenefitIncome > 0);
+
+  const columns: ExportColumn[] = [
+    ...AGE_COLUMNS,
+    ...incomeStreams.map<ExportColumn>(stream => ({
+      key: stream.id,
+      label: stream.name,
+      type: 'currency',
+    })),
+    ...(hasGovernmentBenefits
+      ? [
+          {
+            key: 'governmentBenefits',
+            label: 'Government Benefits',
+            type: 'currency' as const,
+          },
+        ]
+      : []),
+    { key: 'total', label: 'Total', type: 'currency' },
+    FACTOR_COLUMN,
+  ];
+
+  const rows: ExportRow[] = years.map(yearData => {
+    const row: ExportRow = {
+      age: yearData.age,
+      year: yearData.year,
+      total: yearData.governmentBenefitIncome + yearData.incomeStreamIncome,
+      inflationFactor: factorFor(yearData.age),
+    };
+    incomeStreams.forEach(stream => {
+      row[stream.id] = streamShare(
+        stream,
+        yearData.age,
+        yearData.incomeStreamIncome,
+        incomeStreams
+      );
+    });
+    if (hasGovernmentBenefits) {
+      row.governmentBenefits = yearData.governmentBenefitIncome;
+    }
+    return row;
+  });
+
+  const footer: ExportRow = { age: 'Lifetime Total', year: null, inflationFactor: null };
+  incomeStreams.forEach(stream => {
+    footer[stream.id] = years.reduce(
+      (sum, yearData) =>
+        sum +
+        (streamShare(stream, yearData.age, yearData.incomeStreamIncome, incomeStreams) ?? 0),
+      0
+    );
+  });
+  if (hasGovernmentBenefits) {
+    footer.governmentBenefits = years.reduce(
+      (sum, y) => sum + y.governmentBenefitIncome,
+      0
+    );
+  }
+  footer.total = years.reduce(
+    (sum, y) => sum + y.governmentBenefitIncome + y.incomeStreamIncome,
+    0
+  );
+
+  return {
+    id: 'retirement-income-streams',
+    title: 'Retirement — Income Streams',
+    columns,
+    rows,
+    footer,
+    meta,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plan inputs (print report only)
+// ---------------------------------------------------------------------------
+
+export function buildAccountsTable(accounts: Account[], meta: ExportMeta): ExportTable {
+  const rows: ExportRow[] = accounts.map(account => ({
+    name: account.name,
+    type: getAccountTypeLabel(account.type),
+    balance: account.balance,
+    annualContribution: account.annualContribution,
+    contributionGrowthRate: account.contributionGrowthRate,
+    returnRate: account.returnRate,
+    employerMatch: supportsEmployerMatch(account)
+      ? getEmployerMatch(account, account.annualContribution)
+      : null,
+    withdrawalStartAge: account.withdrawalRules?.startAge ?? null,
+  }));
+
+  return {
+    id: 'accounts',
+    title: 'Investment Accounts',
+    columns: [
+      { key: 'name', label: 'Account', type: 'text' },
+      { key: 'type', label: 'Type', type: 'text' },
+      { key: 'balance', label: 'Current Balance', type: 'currency' },
+      { key: 'annualContribution', label: 'Annual Contribution', type: 'currency' },
+      { key: 'employerMatch', label: 'Employer Match', type: 'currency' },
+      { key: 'contributionGrowthRate', label: 'Contribution Growth', type: 'percent' },
+      { key: 'returnRate', label: 'Return Rate', type: 'percent' },
+      { key: 'withdrawalStartAge', label: 'Withdrawals From Age', type: 'number' },
+    ],
+    rows,
+    meta,
+  };
+}
+
+export function buildIncomeStreamsTable(
+  incomeStreams: IncomeStream[],
+  meta: ExportMeta
+): ExportTable {
+  const rows: ExportRow[] = incomeStreams.map(stream => ({
+    name: stream.name,
+    monthlyAmount: stream.monthlyAmount,
+    annualAmount: stream.monthlyAmount * 12,
+    startAge: stream.startAge,
+    endAge: stream.endAge ?? null,
+    taxTreatment: getIncomeTaxTreatmentLabel(stream.taxTreatment),
+  }));
+
+  return {
+    id: 'income-streams',
+    title: 'Income Streams (in today’s dollars)',
+    columns: [
+      { key: 'name', label: 'Stream', type: 'text' },
+      { key: 'monthlyAmount', label: 'Monthly', type: 'currency' },
+      { key: 'annualAmount', label: 'Annual', type: 'currency' },
+      { key: 'startAge', label: 'Start Age', type: 'number' },
+      { key: 'endAge', label: 'End Age', type: 'number' },
+      { key: 'taxTreatment', label: 'Tax Treatment', type: 'text' },
+    ],
+    rows,
+    meta,
+  };
+}

--- a/src/utils/export/types.ts
+++ b/src/utils/export/types.ts
@@ -1,0 +1,40 @@
+import type { Assumptions, Profile } from '../../types';
+import type { CountryCode } from '../../countries';
+
+export type ExportColumnType = 'text' | 'number' | 'currency' | 'percent' | 'factor';
+
+export interface ExportColumn {
+  key: string;
+  label: string;
+  type: ExportColumnType;
+}
+
+export type ExportCell = string | number | null;
+
+export type ExportRow = Record<string, ExportCell>;
+
+/** Context describing how to read the numbers in an exported table. */
+export interface ExportMeta {
+  generatedAt: Date;
+  country: CountryCode;
+  currency: string;
+  /** Calendar year that "today's dollars" are expressed in. */
+  baseYear: number;
+  profile: Profile;
+  assumptions: Assumptions;
+}
+
+/**
+ * A table in a presentation-neutral form. `csv.ts` serializes it for
+ * spreadsheets; `PrintReport` renders the same structure as HTML.
+ */
+export interface ExportTable {
+  /** Stable slug used for filenames. */
+  id: string;
+  title: string;
+  columns: ExportColumn[];
+  rows: ExportRow[];
+  /** Optional totals row rendered beneath the body. */
+  footer?: ExportRow;
+  meta: ExportMeta;
+}

--- a/src/utils/projections.ts
+++ b/src/utils/projections.ts
@@ -8,9 +8,12 @@ import {
 import type { CountryConfig } from '../countries';
 
 /**
- * Calculate employer match for accounts that support it (401k, employer RRSP)
+ * Calculate employer match for accounts that support it (401k, employer RRSP).
+ *
+ * Exported so that the data tables and exports report the same match the
+ * projection actually applied.
  */
-function calculateEmployerMatch(account: Account): number {
+export function getEmployerMatch(account: Account, contribution: number): number {
   const supportsMatch = is401k(account.type) || account.type === 'employer_rrsp';
 
   if (!supportsMatch || !account.employerMatchPercent || !account.employerMatchLimit) {
@@ -20,8 +23,17 @@ function calculateEmployerMatch(account: Account): number {
   // Match is the lesser of:
   // 1. The match percent times the contribution
   // 2. The match limit
-  const matchAmount = account.annualContribution * account.employerMatchPercent;
+  const matchAmount = contribution * account.employerMatchPercent;
   return Math.min(matchAmount, account.employerMatchLimit);
+}
+
+/** True when this account type can receive an employer match at all. */
+export function supportsEmployerMatch(account: Account): boolean {
+  return (
+    (is401k(account.type) || account.type === 'employer_rrsp') &&
+    !!account.employerMatchPercent &&
+    !!account.employerMatchLimit
+  );
 }
 
 /**
@@ -68,10 +80,7 @@ export function calculateAccumulation(
       const balanceAfterReturn = currentBalance * (1 + account.returnRate);
 
       // 2. Add contribution (with employer match if applicable)
-      const employerMatch = calculateEmployerMatch({
-        ...account,
-        annualContribution: currentContribution,
-      });
+      const employerMatch = getEmployerMatch(account, currentContribution);
       const totalContribution = currentContribution + employerMatch;
 
       // Update balance

--- a/src/utils/storageKeys.ts
+++ b/src/utils/storageKeys.ts
@@ -1,0 +1,14 @@
+/**
+ * localStorage keys used to persist app state.
+ *
+ * Centralized so that features which write the whole persisted state at once
+ * (scenario import, country switching) stay in sync with the individual
+ * `useLocalStorage` call sites.
+ */
+export const STORAGE_KEYS = {
+  accounts: 'retirement-planner-accounts',
+  profile: 'retirement-planner-profile',
+  assumptions: 'retirement-planner-assumptions',
+  incomeStreams: 'retirement-planner-income-streams',
+  country: 'retirement-planner-country',
+} as const;


### PR DESCRIPTION
Three ways to get data out of the planner, built on one shared foundation.

`src/utils/export/tables.ts` turns projection results into presentation-neutral `ExportTable` objects (columns + rows + metadata). `csv.ts` serializes them for spreadsheets and `PrintReport` renders the same objects as HTML, so a column added once shows up in both.

### Save/load plan (JSON)
- Writes all five localStorage keys plus a `schemaVersion` to a dated file.
- Import validates every field with readable errors, drops unknown fields rather than writing them to storage, previews the incoming plan in a confirmation modal, then writes storage and reloads. Reload is the same approach country switching uses: providers re-initialize cleanly instead of syncing state in place.
- Handles cross-country files: account types are country-specific, so the file's country is applied and the modal flags the switch.

### CSV
- One button per data-table view, exporting whichever view is active.
- Header row first so spreadsheets auto-detect it, metadata after a trailing blank line, raw unformatted numbers, UTF-8 BOM, CRLF, RFC 4180 quoting. User-supplied names beginning with a formula character are neutralized.

### Print report
- Full report: cover, plan inputs, summary, charts, year-by-year tables, and methodology, driven by `window.print()` so the browser writes the PDF.
- Mounted off-screen at a fixed 720px (7.5in at 96dpi) because Recharts measures its container and cannot size an element with no layout.
- Charts take a new `animate` prop. Recharts reveals series by animating a clip path from zero width, so without it the report prints blank charts.
- Dark mode is stripped while printing and restored afterward.

### Nominal vs. real dollars
Everything the engine outputs is nominal. Exports keep nominal as the primary columns, add a Real column for headline figures, and carry an Inflation Factor column so any column can be deflated in a spreadsheet. The metadata block and report cover both note that tax brackets are not indexed in this model, so nominal tax figures include real bracket creep.

### Also fixed along the way
- The contributions table omitted the employer match on Canadian employer RRSPs; it only checked for 401(k)s while the projection engine also matches `employer_rrsp`. Both now share `getEmployerMatch` from `projections.ts`.
- The Tax Details rows keyed the inner `<tr>` instead of the wrapping fragment, so React saw unkeyed children.
- `presentValue` was private to `SummaryCards`; it now lives in `export/realDollars` as the single nominal-to-real conversion point.

### Testing
95 new assertions covering CSV escaping and structure, real-dollar conversion, table builders, and scenario round-tripping and validation. Verified end to end in Chromium: both export paths, print output, import confirm/error flows, and a US-to-Canada import round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
