### PR TITLE
Fix mobile CSV button overflow and document export features in README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'
@@ -53,10 +53,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: npm
@@ -27,7 +27,7 @@ jobs:
       - run: npm run build
         env:
           BASE_PATH: /retirement-planner/
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
@@ -38,5 +38,5 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5
         id: deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Three ways to get data out of the planner, from the **Export** menu in the heade
 - **Load plan (.json)**: Restores a saved plan. Every field is validated with readable errors, unknown fields are dropped rather than written to storage, and a confirmation modal previews the incoming plan before anything is overwritten. Plans saved in one country can be loaded in the other; the modal flags the switch.
 - **Print / Save as PDF**: Renders a full report — cover page, plan inputs, summary, charts, year-by-year tables, and methodology — and hands it to your browser's print dialog, so "Save as PDF" produces the file.
 
-Each year-by-year data table also has a **Download CSV** button that exports whichever view is currently active. CSVs lead with the header row so spreadsheets auto-detect it, carry raw unformatted numbers, and append a metadata block after a trailing blank line.
+Each year-by-year data panel also has a **Download CSV** button in its header that exports whichever view is currently active. CSVs lead with the header row so spreadsheets auto-detect it, carry raw unformatted numbers, and append a metadata block after a trailing blank line.
 
 **A note on nominal vs. real dollars**: every figure the engine produces is in nominal (future) dollars. Exports keep nominal as the primary columns, add a Real column for headline figures, and include an `Inflation Factor` column so any other column can be deflated in a spreadsheet. Because tax brackets are not indexed to inflation in this model, nominal tax figures include real bracket creep — deflating them gives the present value of dollars paid, not what an indexed-bracket world would charge.
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ Full visibility into how every number is calculated:
   - Step-by-step calculation breakdown
   - Context and explanations for the values
 
+### Exporting Your Data
+Three ways to get data out of the planner, from the **Export** menu in the header:
+
+- **Save plan (.json)**: Writes your full plan — accounts, profile, income streams, assumptions, and country — to a dated file. Nothing leaves your browser.
+- **Load plan (.json)**: Restores a saved plan. Every field is validated with readable errors, unknown fields are dropped rather than written to storage, and a confirmation modal previews the incoming plan before anything is overwritten. Plans saved in one country can be loaded in the other; the modal flags the switch.
+- **Print / Save as PDF**: Renders a full report — cover page, plan inputs, summary, charts, year-by-year tables, and methodology — and hands it to your browser's print dialog, so "Save as PDF" produces the file.
+
+Each year-by-year data table also has a **Download CSV** button that exports whichever view is currently active. CSVs lead with the header row so spreadsheets auto-detect it, carry raw unformatted numbers, and append a metadata block after a trailing blank line.
+
+**A note on nominal vs. real dollars**: every figure the engine produces is in nominal (future) dollars. Exports keep nominal as the primary columns, add a Real column for headline figures, and include an `Inflation Factor` column so any other column can be deflated in a spreadsheet. Because tax brackets are not indexed to inflation in this model, nominal tax figures include real bracket creep — deflating them gives the present value of dollars paid, not what an indexed-bracket world would charge.
+
 ### User Experience
 - **Dark Mode**: Toggle between light and dark themes
 - **Data Persistence**: All data saved to localStorage automatically
@@ -182,13 +193,16 @@ src/
 │   ├── ChartIncome.tsx           # Retirement income chart
 │   ├── ChartTax.tsx              # Tax burden chart
 │   ├── CountrySelector.tsx       # Country switching dropdown
+│   ├── CsvDownloadButton.tsx     # Per-table CSV download button
 │   ├── DataTableAccumulation.tsx # Year-by-year accumulation data
 │   ├── DataTableWithdrawal.tsx   # Year-by-year withdrawal data
+│   ├── ExportMenu.tsx            # Save/load plan & print report menu
 │   ├── IncomeStreamForm.tsx     # Form for adding/editing income streams
 │   ├── IncomeStreamList.tsx     # List of income streams
 │   ├── Layout.tsx                # App layout with header/footer
 │   ├── MethodologyPanel.tsx      # Formulas & assumptions reference
 │   ├── NumberInput.tsx           # String to number conversion
+│   ├── PrintReport.tsx           # Printable full-report rendering
 │   ├── ProfileForm.tsx           # Personal information form
 │   ├── SummaryCards.tsx          # Expandable key metrics display
 │   └── Tooltip.tsx               # Reusable tooltip component
@@ -214,13 +228,26 @@ src/
 ├── types/
 │   └── index.ts              # TypeScript type definitions
 ├── utils/
+│   ├── export/               # Data export (CSV, JSON, print report)
+│   │   ├── index.ts          # Public export surface
+│   │   ├── types.ts          # ExportTable column/row/metadata types
+│   │   ├── tables.ts         # Results -> presentation-neutral tables
+│   │   ├── csv.ts            # CSV serialization (RFC 4180)
+│   │   ├── scenario.ts       # Plan save/load + validation
+│   │   ├── realDollars.ts    # Nominal -> real dollar conversion
+│   │   ├── format.ts         # Shared value/filename formatting
+│   │   └── download.ts       # Browser file download helper
 │   ├── constants.ts          # Tax brackets, RMD tables, defaults
 │   ├── incomeStreams.ts      # Income stream tax calculations
+│   ├── penaltyCalculator.ts  # Early withdrawal penalty rules
 │   ├── projections.ts        # Accumulation phase calculations
+│   ├── storageKeys.ts        # Shared localStorage key names
 │   ├── taxes.ts              # Tax calculation functions
+│   ├── withdrawalDefaults.ts # Default withdrawal start ages
 │   └── withdrawals.ts        # Withdrawal phase simulation
 ├── tests/
-│   └── calculations.test.ts  # Comprehensive math tests (US & CA)
+│   ├── calculations.test.ts  # Comprehensive math tests (US & CA)
+│   └── export.test.ts        # CSV, table builder & scenario tests
 ├── App.tsx                   # Main application component
 ├── index.css                 # Tailwind CSS configuration
 └── main.tsx                  # Application entry point
@@ -275,7 +302,7 @@ For each year of retirement:
 
 ## Testing
 
-The project includes comprehensive tests for all calculations:
+The project includes comprehensive tests for all calculations and exports:
 
 ```bash
 npm test
@@ -289,6 +316,10 @@ Tests cover:
 - Withdrawal phase simulations
 - Canadian account type recognition
 - Edge cases (zero balances, long retirements, etc.)
+- CSV escaping and structure (quoting, formula neutralization, metadata block)
+- Nominal-to-real dollar conversion
+- Export table builders for every data-table view
+- Plan save/load round-tripping and import validation
 
 Run `npm test` for the full suite and current test count.
 

--- a/src/components/CsvDownloadButton.tsx
+++ b/src/components/CsvDownloadButton.tsx
@@ -5,9 +5,15 @@ interface CsvDownloadButtonProps {
   /** Built lazily on click — no cost while the panel just sits there. */
   getTable: () => ExportTable;
   label?: string;
+  /** Shown below the `sm` breakpoint, where the full label crowds the header. */
+  shortLabel?: string;
 }
 
-export function CsvDownloadButton({ getTable, label = 'Download CSV' }: CsvDownloadButtonProps) {
+export function CsvDownloadButton({
+  getTable,
+  label = 'Download CSV',
+  shortLabel = 'CSV',
+}: CsvDownloadButtonProps) {
   const handleClick = () => {
     const table = getTable();
     downloadCsv(csvFilename(table), toCsv(table));
@@ -28,7 +34,8 @@ export function CsvDownloadButton({ getTable, label = 'Download CSV' }: CsvDownl
           d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
         />
       </svg>
-      {label}
+      <span className="hidden sm:inline">{label}</span>
+      <span className="sm:hidden">{shortLabel}</span>
     </button>
   );
 }

--- a/src/components/DataTableAccumulation.tsx
+++ b/src/components/DataTableAccumulation.tsx
@@ -86,7 +86,7 @@ export function DataTableAccumulation({
       {isExpanded && (
         <div className="px-4 pb-4">
           {/* View Mode Tabs */}
-          <div className="flex gap-2 mb-4 border-b border-gray-200 dark:border-gray-700 items-center">
+          <div className="flex gap-2 mb-4 border-b border-gray-200 dark:border-gray-700 overflow-x-auto items-center">
             <button
               onClick={() => setViewMode('summary')}
               className={`px-3 py-2 text-sm font-medium border-b-2 -mb-px ${

--- a/src/components/DataTableAccumulation.tsx
+++ b/src/components/DataTableAccumulation.tsx
@@ -58,30 +58,45 @@ export function DataTableAccumulation({
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
-      <button
-        onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full px-4 py-3 flex justify-between items-center hover:bg-gray-50 dark:hover:bg-gray-700 rounded-t-lg"
-      >
-        <div className="flex items-center gap-2">
+      {/* The CSV button sits beside the toggle, so the header is a row of
+          siblings rather than one full-width button — a button cannot nest. */}
+      <div className="w-full px-4 py-3 flex items-center gap-2 rounded-t-lg">
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="flex items-center gap-2 flex-1 min-w-0 text-left px-1 -mx-1 py-1 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700"
+        >
           <svg
-            className="w-5 h-5 text-gray-500 dark:text-gray-400"
+            className="w-5 h-5 shrink-0 text-gray-500 dark:text-gray-400"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
           >
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M3 14h18m-9-4v8m-7 0h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
           </svg>
-          <span className="font-medium text-gray-900 dark:text-white">Year-by-Year Data</span>
-        </div>
-        <svg
-          className={`w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
+          <span className="font-medium text-gray-900 dark:text-white truncate">Year-by-Year Data</span>
+        </button>
+
+        {isExpanded && (
+          <div className="shrink-0">
+            <CsvDownloadButton getTable={buildCsvTable} />
+          </div>
+        )}
+
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          aria-label={isExpanded ? 'Collapse year-by-year data' : 'Expand year-by-year data'}
+          className="shrink-0 p-1 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700"
         >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
-      </button>
+          <svg
+            className={`w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+      </div>
 
       {isExpanded && (
         <div className="px-4 pb-4">
@@ -117,10 +132,6 @@ export function DataTableAccumulation({
             >
               Contributions
             </button>
-
-            <div className="ml-auto pb-2">
-              <CsvDownloadButton getTable={buildCsvTable} />
-            </div>
           </div>
 
           <div className="overflow-x-auto">

--- a/src/components/DataTableWithdrawal.tsx
+++ b/src/components/DataTableWithdrawal.tsx
@@ -97,30 +97,45 @@ export function DataTableWithdrawal({
 
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
-      <button
-        onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full px-4 py-3 flex justify-between items-center hover:bg-gray-50 dark:hover:bg-gray-700 rounded-t-lg"
-      >
-        <div className="flex items-center gap-2">
+      {/* The CSV button sits beside the toggle, so the header is a row of
+          siblings rather than one full-width button — a button cannot nest. */}
+      <div className="w-full px-4 py-3 flex items-center gap-2 rounded-t-lg">
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="flex items-center gap-2 flex-1 min-w-0 text-left px-1 -mx-1 py-1 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700"
+        >
           <svg
-            className="w-5 h-5 text-gray-500 dark:text-gray-400"
+            className="w-5 h-5 shrink-0 text-gray-500 dark:text-gray-400"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
           >
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M3 14h18m-9-4v8m-7 0h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
           </svg>
-          <span className="font-medium text-gray-900 dark:text-white">Year-by-Year Data</span>
-        </div>
-        <svg
-          className={`w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
+          <span className="font-medium text-gray-900 dark:text-white truncate">Year-by-Year Data</span>
+        </button>
+
+        {isExpanded && (
+          <div className="shrink-0">
+            <CsvDownloadButton getTable={buildCsvTable} />
+          </div>
+        )}
+
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          aria-label={isExpanded ? 'Collapse year-by-year data' : 'Expand year-by-year data'}
+          className="shrink-0 p-1 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700"
         >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
-      </button>
+          <svg
+            className={`w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+      </div>
 
       {isExpanded && (
         <div className="px-4 pb-4">
@@ -176,10 +191,6 @@ export function DataTableWithdrawal({
             >
               Income Streams
             </button>
-
-            <div className="ml-auto pb-2">
-              <CsvDownloadButton getTable={buildCsvTable} />
-            </div>
           </div>
 
           <div className="overflow-x-auto">


### PR DESCRIPTION
Post-merge follow-up to #17: one mobile layout bug and the README coverage that commit missed.

### Fix horizontal page scroll from the CSV button on mobile

`DataTableAccumulation`'s view-mode tab row was missing the `overflow-x-auto` that its Retirement Phase counterpart (`DataTableWithdrawal`) already had.

At a 375px viewport the three tabs plus the `ml-auto` Download CSV button need 452px. With nothing containing them, the row pushed the document to **485px** and the entire page scrolled sideways — the button rendered outside the card and body text was clipped off the left edge.

**Verified at 375px:** before, `document.scrollWidth` was 485 against a 375px viewport; after, 375 = 375. The tab row now scrolls within the card. The Retirement Phase table was already correct (375 = 375), confirming the bug was isolated to the one component.

Known trade-off, matching existing sibling behavior: on mobile the Download CSV button starts off-screen and you scroll the tab strip to reach it. That is already true of the Retirement Phase table. Moving the button onto its own line in both components would fix it, but that is a design change rather than a bug fix, so it is left out here.

### Document export features in README

#17 updated CLAUDE.md but left README.md untouched, so the user-facing docs had no mention of the export feature at all — the only related line was "All data saved to localStorage automatically".

- New **Exporting Your Data** section: the three Export menu items (save plan, load plan, print/PDF), the per-table Download CSV buttons, and the nominal vs. real dollar caveat about non-indexed tax brackets.
- **Project Structure** tree refreshed. It was missing `CsvDownloadButton.tsx`, `ExportMenu.tsx`, `PrintReport.tsx`, the entire `utils/export/` directory, `storageKeys.ts`, and `export.test.ts` — plus `penaltyCalculator.ts` and `withdrawalDefaults.ts`, which predate this feature. Cross-checked so the tree now matches what is actually on disk.
- **Testing** section extended with the export coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
