### PR TITLE
Fix calculation-correctness issues found in engine review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ This is a React retirement planning calculator that projects portfolio growth an
    - Falls back to additional traditional withdrawals if needed
    - Final fallback: if all available accounts are exhausted, withdraws from accounts before their configured start age, incurring early-withdrawal penalties (10% for US traditional accounts before age 59.5)
 
-3. **Tax Calculations** (`src/utils/taxes.ts`): Each country exposes a consolidated `calculateYearlyTaxes` that computes federal + regional tax including capital gains (US: 2026 brackets with 0%/15%/20% capital gains rates; Canada: 50% capital gains inclusion stacked on ordinary income). CPP and OAS are modeled as 100% taxable; US Social Security income streams are 85% taxable (maximum portion).
+3. **Tax Calculations** (`src/utils/taxes.ts`): Each country exposes a consolidated `calculateYearlyTaxes` that computes federal + regional tax including capital gains (US: 2026 brackets with 0%/15%/20% capital gains rates; Canada: 50% capital gains inclusion stacked on ordinary income). Brackets, deductions, basic personal amounts, and the OAS clawback threshold are indexed by the assumed inflation rate for future years (via the `indexFactor` parameter and `scaleBrackets` in `src/utils/taxBrackets.ts`), matching how both countries index them in law. CPP and OAS are modeled as 100% taxable; US Social Security taxability follows the provisional-income phase-in (0–85%, `calculateTaxableSocialSecurity`) with statutorily frozen thresholds that are deliberately NOT inflation-indexed. The bracket-fill planning step still estimates benefit income at the flat 85% maximum (the exact amount depends on withdrawals not yet decided at that point). The OAS clawback compares prior-year taxable income (deflated to today's dollars) against the current-year threshold — all clawback math is done in today's dollars.
 
 ### Data Flow
 
@@ -61,7 +61,7 @@ Three export paths share one foundation. `tables.ts` turns results into presenta
 
 **Nominal vs. real dollars:**
 
-Everything the engine outputs is nominal (future) dollars. `presentValue`/`inflationFactor` in `export/realDollars.ts` are the single conversion point, used by both `SummaryCards` and the exports. Exports carry nominal as the primary columns, a Real column for headline figures, and an `Inflation Factor` column so any other column can be deflated in a spreadsheet. Note that tax brackets are not indexed to inflation in this model, so nominal tax figures include real bracket creep — deflating them gives the present value of dollars paid, not what an indexed-bracket world would charge.
+Everything the engine outputs is nominal (future) dollars. `presentValue`/`inflationFactor` in `export/realDollars.ts` are the single conversion point, used by both `SummaryCards` and the exports. Exports carry nominal as the primary columns, a Real column for headline figures, and an `Inflation Factor` column so any other column can be deflated in a spreadsheet. Tax brackets and thresholds are indexed to the assumed inflation rate, so deflated tax figures reflect constant real tax policy (no artificial bracket creep).
 
 **Known Simplifications (Penalty Calculations):**
 - Roth contributions vs earnings not tracked separately. In reality, Roth contributions can be withdrawn penalty-free at any time; only earnings face the 10% penalty before age 59.5.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import { useRetirementCalc } from './hooks/useRetirementCalc';
 import { useLocalStorage, useDarkMode } from './hooks/useLocalStorage';
 import { CountryProvider, useCountry } from './contexts/CountryContext';
 import { getCountryConfig, type CountryCode } from './countries';
-import { getDefaultWithdrawalAge } from './utils/withdrawalDefaults';
+import { getDefaultWithdrawalAge, birthYearFromAge } from './utils/withdrawalDefaults';
 import { Layout } from './components/Layout';
 import { AccountList } from './components/AccountList';
 import { ProfileForm } from './components/ProfileForm';
@@ -99,7 +99,12 @@ function normalizeAccount(
 
   // Apply default withdrawal age based on account type and country config
   const countryConfig = getCountryConfig(profile.country);
-  const defaultAge = getDefaultWithdrawalAge(account, profile.retirementAge, countryConfig);
+  const defaultAge = getDefaultWithdrawalAge(
+    account,
+    profile.retirementAge,
+    countryConfig,
+    birthYearFromAge(profile.currentAge)
+  );
 
   return {
     ...account,

--- a/src/components/AccountForm.tsx
+++ b/src/components/AccountForm.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
-import { Account, AccountType, Profile, getAccountTypeLabel, is401k } from '../types';
+import { Account, AccountType, Profile, getAccountTypeLabel, is401k, getTaxTreatment } from '../types';
 import { NumberInput } from './NumberInput';
 import { Tooltip } from './Tooltip';
 import { v4 as uuidv4 } from 'uuid';
 import { useCountry } from '../contexts/CountryContext';
-import { getDefaultWithdrawalAge, getMaxWithdrawalAge } from '../utils/withdrawalDefaults';
+import { getDefaultWithdrawalAge, getMaxWithdrawalAge, birthYearFromAge } from '../utils/withdrawalDefaults';
 import { getCountryConfig } from '../countries';
 
 interface AccountFormProps {
@@ -49,10 +49,12 @@ export function AccountForm({ account, profile, onSave, onCancel }: AccountFormP
 
   // Calculate min/max withdrawal ages
   const minWithdrawalAge = profile.currentAge;
+  const birthYear = birthYearFromAge(profile.currentAge);
   const maxWithdrawalAge = getMaxWithdrawalAge(
     { ...formData, id: account?.id || '' },
     profile.lifeExpectancy,
-    fullCountryConfig
+    fullCountryConfig,
+    birthYear
   );
 
   // Get current withdrawal age (or default)
@@ -60,7 +62,8 @@ export function AccountForm({ account, profile, onSave, onCancel }: AccountFormP
     getDefaultWithdrawalAge(
       { ...formData, id: account?.id || '' },
       profile.retirementAge,
-      fullCountryConfig
+      fullCountryConfig,
+      birthYear
     );
 
   // Derive warning state instead of storing in state
@@ -96,6 +99,14 @@ export function AccountForm({ account, profile, onSave, onCancel }: AccountFormP
       newErrors.annualContribution = 'Contribution cannot be negative';
     }
 
+    if (formData.costBasis !== undefined) {
+      if (formData.costBasis < 0) {
+        newErrors.costBasis = 'Cost basis cannot be negative';
+      } else if (formData.costBasis > formData.balance) {
+        newErrors.costBasis = 'Cost basis cannot exceed the current balance';
+      }
+    }
+
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
@@ -105,9 +116,17 @@ export function AccountForm({ account, profile, onSave, onCancel }: AccountFormP
 
     if (!validate()) return;
 
+    // Cost basis only applies to taxable accounts; drop it if the account
+    // type was switched to something else.
+    const { costBasis, ...rest } = formData;
+    const saved: Omit<Account, 'id'> =
+      getTaxTreatment(formData.type) === 'taxable' && costBasis !== undefined
+        ? { ...rest, costBasis }
+        : rest;
+
     onSave({
       id: account?.id || uuidv4(),
-      ...formData,
+      ...saved,
     });
   };
 
@@ -166,6 +185,23 @@ export function AccountForm({ account, profile, onSave, onCancel }: AccountFormP
           />
           {errors.balance && <p className="text-red-500 text-xs mt-1">{errors.balance}</p>}
         </div>
+
+        {getTaxTreatment(formData.type) === 'taxable' && (
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Cost Basis ($)
+              <Tooltip text="The amount you originally invested (contributions, not growth). Used to compute the taxable gains portion of withdrawals. Leave equal to the balance if you have no unrealized gains; future contributions are added to it automatically." />
+            </label>
+            <NumberInput
+              value={formData.costBasis ?? formData.balance}
+              onChange={(val) => handleChange('costBasis', val)}
+              min={0}
+              defaultValue={formData.balance}
+              className={errors.costBasis ? inputErrorClassName : inputClassName}
+            />
+            {errors.costBasis && <p className="text-red-500 text-xs mt-1">{errors.costBasis}</p>}
+          </div>
+        )}
 
         <div>
           <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
@@ -292,7 +328,8 @@ export function AccountForm({ account, profile, onSave, onCancel }: AccountFormP
             Default: {getDefaultWithdrawalAge(
               { ...formData, id: account?.id || '' },
               profile.retirementAge,
-              fullCountryConfig
+              fullCountryConfig,
+              birthYear
             )}
             {maxWithdrawalAge < profile.lifeExpectancy && ` (Max: ${maxWithdrawalAge} due to RMD)`}
           </p>

--- a/src/components/AccountList.tsx
+++ b/src/components/AccountList.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Account, Profile, getAccountTypeLabel, getTaxTreatment } from '../types';
 import { AccountForm } from './AccountForm';
 import { CHART_COLORS } from '../utils/constants';
-import { getDefaultWithdrawalAge } from '../utils/withdrawalDefaults';
+import { getDefaultWithdrawalAge, birthYearFromAge } from '../utils/withdrawalDefaults';
 import type { CountryConfig } from '../countries';
 
 interface AccountListProps {
@@ -103,7 +103,7 @@ export function AccountList({ accounts, profile, countryConfig, onAdd, onUpdate,
                 <div>
                   <div className="font-medium text-gray-900 dark:text-white">{account.name}</div>
                   <div className="text-sm text-gray-500 dark:text-gray-400">
-                    {getAccountTypeLabel(account.type)} <br />Age {account.withdrawalRules?.startAge ?? getDefaultWithdrawalAge(account, profile.retirementAge, countryConfig)}+
+                    {getAccountTypeLabel(account.type)} <br />Age {account.withdrawalRules?.startAge ?? getDefaultWithdrawalAge(account, profile.retirementAge, countryConfig, birthYearFromAge(profile.currentAge))}+
                   </div>
                 </div>
               </div>

--- a/src/components/IncomeStreamForm.tsx
+++ b/src/components/IncomeStreamForm.tsx
@@ -15,7 +15,7 @@ const inputErrorClassName = "w-full px-3 py-2 border border-red-500 rounded-md s
 const TAX_TREATMENTS: IncomeTaxTreatment[] = ['social_security', 'fully_taxable', 'other_income', 'tax_free'];
 
 const TAX_TREATMENT_DESCRIPTIONS: Record<IncomeTaxTreatment, string> = {
-  social_security: '85% taxable at your ordinary income rate',
+  social_security: '0–85% taxable via the IRS provisional-income phase-in',
   fully_taxable: '100% taxable as ordinary income',
   other_income: '100% taxable as ordinary income',
   tax_free: 'Not included in taxable income (e.g., VA disability)',

--- a/src/components/MethodologyPanel.tsx
+++ b/src/components/MethodologyPanel.tsx
@@ -9,8 +9,9 @@ import {
   CAPITAL_GAINS_BRACKETS_MFJ,
   CAPITAL_GAINS_BRACKETS_SINGLE,
   RMD_TABLE,
-  RMD_START_AGE,
+  getRMDStartAge,
 } from '../utils/constants';
+import { birthYearFromAge } from '../utils/withdrawalDefaults';
 import {
   TAX_DATA_YEAR as CA_TAX_DATA_YEAR,
   FEDERAL_TAX_BRACKETS as CA_FEDERAL_BRACKETS,
@@ -50,6 +51,8 @@ export function MethodologyPanel({ profile, assumptions }: MethodologyPanelProps
 
   // US-specific values
   const isMarried = profile.filingStatus === 'married_filing_jointly';
+  // SECURE 2.0: RMDs start at 73 for those born before 1960, 75 otherwise
+  const rmdStartAge = getRMDStartAge(birthYearFromAge(profile.currentAge));
   const taxBrackets = isMarried ? TAX_BRACKETS_MFJ : TAX_BRACKETS_SINGLE;
   const standardDeduction = isMarried ? STANDARD_DEDUCTION_MFJ : STANDARD_DEDUCTION_SINGLE;
   const capitalGainsBrackets = isMarried ? CAPITAL_GAINS_BRACKETS_MFJ : CAPITAL_GAINS_BRACKETS_SINGLE;
@@ -223,7 +226,7 @@ export function MethodologyPanel({ profile, assumptions }: MethodologyPanelProps
                 <div>
                   <strong className="text-gray-800 dark:text-gray-200">Additional RRSP/RRIF Withdrawals</strong>
                   <p className="text-gray-600 dark:text-gray-400">
-                    Additional withdrawals from registered accounts (RRSP, RRIF, LIRA, LIF, FHSA) to fill the first federal tax bracket (up to {formatCurrency(caBracketFillTarget, currency)} total ordinary income, combining the {formatCurrency(CA_BASIC_PERSONAL, currency)} basic personal amount and the {formatCurrency(CA_FEDERAL_BRACKETS[0].max, currency)} top of the 15% bracket).
+                    Additional withdrawals from registered accounts (RRSP, RRIF, LIRA, LIF, FHSA) to fill the first federal tax bracket (up to {formatCurrency(caBracketFillTarget, currency)} total ordinary income, combining the {formatCurrency(CA_BASIC_PERSONAL, currency)} basic personal amount and the {formatCurrency(CA_FEDERAL_BRACKETS[0].max, currency)} top of the {formatPercent(CA_FEDERAL_BRACKETS[0].rate)} bracket).
                   </p>
                 </div>
               </li>
@@ -265,7 +268,7 @@ export function MethodologyPanel({ profile, assumptions }: MethodologyPanelProps
                 <span className="flex-shrink-0 w-6 h-6 rounded-full bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400 flex items-center justify-center text-xs font-bold">1</span>
                 <div>
                   <strong className="text-gray-800 dark:text-gray-200">Required Minimum Distributions (RMDs)</strong>
-                  <p className="text-gray-600 dark:text-gray-400">Starting at age {RMD_START_AGE}, traditional accounts must take RMDs based on IRS life expectancy tables.</p>
+                  <p className="text-gray-600 dark:text-gray-400">Starting at age {rmdStartAge} (based on your birth year, per SECURE 2.0), traditional accounts must take RMDs based on IRS life expectancy tables.</p>
                 </div>
               </li>
               <li className="flex gap-3">
@@ -349,10 +352,13 @@ export function MethodologyPanel({ profile, assumptions }: MethodologyPanelProps
             ) : (
               <>
                 <code className="text-xs bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded block mb-2 text-gray-800 dark:text-gray-200">
-                  Taxable Income = Traditional Withdrawals + (Social Security × 85%) - Standard Deduction
+                  Taxable Income = Traditional Withdrawals + Taxable Social Security - Standard Deduction
                 </code>
                 <p className="text-gray-600 dark:text-gray-400">
                   Progressive brackets applied to taxable income (see table below).
+                  The taxable share of Social Security (0% to 85%) follows the IRS provisional-income
+                  phase-in; its thresholds are frozen by law (not inflation-indexed), so most retirees
+                  reach the 85% maximum over long horizons.
                 </p>
               </>
             )}
@@ -537,7 +543,7 @@ export function MethodologyPanel({ profile, assumptions }: MethodologyPanelProps
                   RMD = Traditional Account Balance / Life Expectancy Divisor
                 </code>
                 <p className="text-gray-600 dark:text-gray-400">
-                  RMDs begin at age {RMD_START_AGE} per the SECURE 2.0 Act. The divisor decreases with age, requiring larger withdrawals.
+                  RMDs begin at age {rmdStartAge} per the SECURE 2.0 Act (73 if born before 1960, 75 otherwise). The divisor decreases with age, requiring larger withdrawals.
                 </p>
               </>
             )}
@@ -614,9 +620,9 @@ export function MethodologyPanel({ profile, assumptions }: MethodologyPanelProps
                   <li>• Maximum monthly benefit at 65: {formatCurrency(OAS_MAX_MONTHLY, currency)}/month</li>
                   <li>• Available from age 65 to 70</li>
                   <li>• Deferral increases benefit by 0.6% per month</li>
-                  <li>• Clawback begins at {formatCurrency(OAS_CLAWBACK_THRESHOLD, currency)} net income</li>
+                  <li>• Clawback begins at {formatCurrency(OAS_CLAWBACK_THRESHOLD, currency)} net income (in today's dollars; the threshold is indexed to inflation)</li>
                   <li>• Clawback rate: 15% of income above threshold</li>
-                  <li>• Clawback is based on the prior year's simulated net income (the first retirement year uses an estimate based on target spending)</li>
+                  <li>• Clawback is based on the prior year's simulated taxable income (the first retirement year uses an estimate based on target spending)</li>
                 </ul>
               </div>
             </>
@@ -627,7 +633,7 @@ export function MethodologyPanel({ profile, assumptions }: MethodologyPanelProps
                 <li>• Configure Social Security, pensions, and other retirement income in the Income Streams panel</li>
                 <li>• Each stream has a name, monthly benefit, start age, and tax treatment</li>
                 <li>• Benefits are inflation-adjusted annually</li>
-                <li>• Social Security streams: 85% taxable (maximum rate)</li>
+                <li>• Social Security streams: 0–85% taxable via the IRS provisional-income phase-in (thresholds frozen by law)</li>
                 <li>• Pension streams: 100% taxable as ordinary income</li>
                 <li>• Tax-free streams (e.g., VA disability): excluded from taxable income</li>
               </ul>
@@ -644,7 +650,7 @@ export function MethodologyPanel({ profile, assumptions }: MethodologyPanelProps
         <ul className="space-y-2 text-sm text-amber-700 dark:text-amber-300">
           <li className="flex gap-2">
             <span className="flex-shrink-0">*</span>
-            <span>Tax brackets are for {isCanada ? CA_TAX_DATA_YEAR : TAX_DATA_YEAR} and don't adjust for inflation in future years.</span>
+            <span>Tax brackets, deductions, and personal amounts are {isCanada ? CA_TAX_DATA_YEAR : TAX_DATA_YEAR} values, assumed to grow with your inflation assumption in future years (both countries index them to inflation by law).</span>
           </li>
           {isCanada ? (
             <>
@@ -654,11 +660,19 @@ export function MethodologyPanel({ profile, assumptions }: MethodologyPanelProps
               </li>
               <li className="flex gap-2">
                 <span className="flex-shrink-0">*</span>
-                <span>OAS clawback is based on the prior year's simulated net income (the first retirement year is estimated from target spending) and may not reflect all income sources.</span>
+                <span>OAS clawback is based on the prior year's simulated taxable income (the first retirement year is estimated from target spending). The clawback threshold is assumed to grow with inflation, matching how it is indexed in law.</span>
               </li>
               <li className="flex gap-2">
                 <span className="flex-shrink-0">*</span>
-                <span>Quebec has a separate tax system; calculations use simplified Quebec brackets.</span>
+                <span>Quebec has a separate tax system; calculations use simplified Quebec brackets and apply the 16.5% federal abatement for Quebec residents.</span>
+              </li>
+              <li className="flex gap-2">
+                <span className="flex-shrink-0">*</span>
+                <span>The Ontario surtax (20%/36% on basic provincial tax) is modeled; the Ontario Health Premium (up to $900/year) is not.</span>
+              </li>
+              <li className="flex gap-2">
+                <span className="flex-shrink-0">*</span>
+                <span>LIRA/LIF accounts follow RRIF minimum withdrawals from age 71; LIF withdrawal maximums are not modeled.</span>
               </li>
               <li className="flex gap-2">
                 <span className="flex-shrink-0">*</span>
@@ -673,7 +687,7 @@ export function MethodologyPanel({ profile, assumptions }: MethodologyPanelProps
             <>
               <li className="flex gap-2">
                 <span className="flex-shrink-0">*</span>
-                <span>Social Security is assumed 85% taxable (maximum taxable portion).</span>
+                <span>Social Security taxability uses the provisional-income phase-in (0% to 85%). The withdrawal strategy's bracket-fill step estimates with the 85% maximum before the year's exact income is known.</span>
               </li>
               <li className="flex gap-2">
                 <span className="flex-shrink-0">*</span>
@@ -687,7 +701,11 @@ export function MethodologyPanel({ profile, assumptions }: MethodologyPanelProps
           )}
           <li className="flex gap-2">
             <span className="flex-shrink-0">*</span>
-            <span>Taxable account cost basis is estimated at 50% of the balance at retirement.</span>
+            <span>Taxable account cost basis starts from the account's Cost Basis input (defaulting to the full current balance) and grows with each contribution; investment growth is treated as unrealized gains until withdrawn.</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="flex-shrink-0">*</span>
+            <span>Annual taxes on dividends and interest inside taxable accounts (tax drag) are not modeled; gains are only taxed when withdrawn.</span>
           </li>
           <li className="flex gap-2">
             <span className="flex-shrink-0">*</span>

--- a/src/components/SummaryCards.tsx
+++ b/src/components/SummaryCards.tsx
@@ -215,9 +215,12 @@ export function SummaryCards({
   const lifetimeFederalTax = yearlyWithdrawals.reduce((sum, y) => sum + y.federalTax, 0);
   const lifetimeStateTax = yearlyWithdrawals.reduce((sum, y) => sum + y.stateTax, 0);
 
-  // Calculate average effective tax rate
-  const avgEffectiveTaxRate = yearlyWithdrawals.length > 0
-    ? yearlyWithdrawals.reduce((sum, y) => sum + (y.grossIncome > 0 ? y.totalTax / y.grossIncome : 0), 0) / yearlyWithdrawals.length
+  // Lifetime effective tax rate, dollar-weighted (total tax / total income).
+  // Matches the taxes export footer; an unweighted average of yearly rates
+  // would let low-income years dilute the figure.
+  const lifetimeGrossIncome = yearlyWithdrawals.reduce((sum, y) => sum + y.grossIncome, 0);
+  const avgEffectiveTaxRate = lifetimeGrossIncome > 0
+    ? lifetimeTaxesPaid / lifetimeGrossIncome
     : 0;
 
   // Lifetime early-withdrawal penalties, nominal and real.
@@ -400,7 +403,7 @@ export function SummaryCards({
                   )}
                 </ul>
                 <p className="mb-1">
-                  Average effective tax rate: {formatPercent(avgEffectiveTaxRate)}
+                  Lifetime effective tax rate: {formatPercent(avgEffectiveTaxRate)}
                 </p>
                 {todayHint(lifetimeTaxesPaid, lifetimeTaxesReal) && (
                   <p className="mb-1 text-gray-500 dark:text-gray-400 italic">
@@ -491,7 +494,7 @@ export function SummaryCards({
                   <p>
                     {isCanada
                       ? 'CPP is fully taxable as ordinary income.'
-                      : '85% of Social Security is included as taxable income (maximum taxable portion).'}
+                      : 'Up to 85% of Social Security is taxable, following the IRS provisional-income phase-in.'}
                   </p>
                 </div>
               }

--- a/src/countries/canada/benefits.ts
+++ b/src/countries/canada/benefits.ts
@@ -62,10 +62,17 @@ export function calculateOASAdjustment(
 }
 
 /**
- * Calculate OAS clawback (recovery tax)
- * @param netIncome - Net income for the year (before OAS)
- * @param oasAmount - Annual OAS received
- * @returns Amount of OAS that must be repaid
+ * Calculate OAS clawback (recovery tax).
+ *
+ * All amounts are in TODAY'S dollars: the threshold constants are
+ * current-year figures, so the income being tested and the OAS amount must
+ * be deflated to today's dollars before calling. (The clawback threshold is
+ * indexed to inflation in law, so comparing deflated income against the
+ * current threshold is equivalent to indexing the threshold.)
+ *
+ * @param netIncome - Prior-year taxable income in today's dollars
+ * @param oasAmount - Annual OAS in today's dollars
+ * @returns Amount of OAS that must be repaid, in today's dollars
  */
 export function calculateOASClawback(netIncome: number, oasAmount: number): number {
   if (netIncome <= OAS_CLAWBACK_THRESHOLD) return 0;
@@ -78,12 +85,18 @@ export function calculateOASClawback(netIncome: number, oasAmount: number): numb
 }
 
 /**
- * Calculate CPP and OAS benefits for a given year
+ * Calculate CPP and OAS benefits for a given year.
+ *
+ * Returns amounts in today's dollars; the engine inflates them afterwards.
+ *
+ * @param meansTestIncome - Prior-year taxable income in TODAY'S dollars,
+ *   used for the OAS clawback. Passing nominal future-year income here
+ *   would overstate the clawback badly for long horizons.
  */
 export function calculateCanadianRetirementBenefits(
   profile: Profile,
   currentAge: number,
-  grossIncome: number
+  meansTestIncome: number
 ): BenefitCalculation[] {
   const benefits: BenefitCalculation[] = [];
 
@@ -117,7 +130,7 @@ export function calculateCanadianRetirementBenefits(
     const annualOAS = adjustedOASMonthly * 12;
 
     // Calculate clawback
-    const clawback = calculateOASClawback(grossIncome, annualOAS);
+    const clawback = calculateOASClawback(meansTestIncome, annualOAS);
     const netOAS = annualOAS - clawback;
 
     if (netOAS > 0) {

--- a/src/countries/canada/constants.ts
+++ b/src/countries/canada/constants.ts
@@ -115,6 +115,20 @@ export const PROVINCIAL_TAX_BRACKETS: Record<string, TaxBracket[]> = {
   ],
 };
 
+// Ontario surtax (2026): 20% of basic ON tax above the first threshold plus
+// 36% of basic ON tax above the second (both apply concurrently above the
+// second threshold). Thresholds are indexed to inflation annually.
+export const ONTARIO_SURTAX = {
+  threshold1: 5818,
+  rate1: 0.20,
+  threshold2: 7446,
+  rate2: 0.36,
+};
+
+// Quebec abatement: QC residents receive a 16.5% reduction of basic federal
+// tax (in lieu of federal cash transfers for provincially run programs).
+export const QUEBEC_ABATEMENT_RATE = 0.165;
+
 export const PROVINCIAL_BASIC_PERSONAL_AMOUNTS: Record<string, number> = {
   AB: 22769, // 2026
   BC: 13216, // 2026

--- a/src/countries/canada/index.ts
+++ b/src/countries/canada/index.ts
@@ -10,6 +10,8 @@ import {
   FEDERAL_BASIC_PERSONAL_AMOUNT,
   FEDERAL_TAX_BRACKETS,
   CAPITAL_GAINS_INCLUSION_RATE_DEFAULT,
+  RRIF_START_AGE,
+  QUEBEC_ABATEMENT_RATE,
 } from './constants';
 import { CHART_COLORS } from '../../utils/constants';
 
@@ -113,8 +115,9 @@ export const CAConfig: CountryConfig = {
   calculateYearlyTaxes: (
     ordinaryIncome: number,
     capitalGains: number,
-    profile: Profile
-  ): { federalTax: number; regionalTax: number } => {
+    profile: Profile,
+    indexFactor: number = 1
+  ): { federalTax: number; regionalTax: number; taxableIncome: number } => {
     // Capital gains are included in taxable income at a flat 50% inclusion
     // rate and stack on top of ordinary income.
     const taxableCapitalGains = Math.max(0, capitalGains) * CAPITAL_GAINS_INCLUSION_RATE_DEFAULT;
@@ -122,15 +125,32 @@ export const CAConfig: CountryConfig = {
 
     // Federal and provincial brackets each apply their own basic personal
     // amount exactly once against the combined taxable income.
-    const federalTax = calculateFederalIncomeTax(taxableIncome);
-    const regionalTax = calculateProvincialIncomeTax(taxableIncome, profile.region || '');
+    let federalTax = calculateFederalIncomeTax(taxableIncome, indexFactor);
+    const regionalTax = calculateProvincialIncomeTax(taxableIncome, profile.region || '', indexFactor);
 
-    return { federalTax, regionalTax };
+    // Quebec residents receive the 16.5% federal abatement.
+    if (profile.region === 'QC') {
+      federalTax *= 1 - QUEBEC_ABATEMENT_RATE;
+    }
+
+    return { federalTax, regionalTax, taxableIncome };
   },
 
   getGovernmentBenefitTaxableRate: (): number => {
     // CPP and OAS are fully taxable in Canada
     return 1.0;
+  },
+
+  getTaxableGovernmentBenefits: (
+    governmentBenefitIncome: number,
+    ssStreamIncome: number,
+    _otherOrdinaryIncome: number,
+    _profile: Profile
+  ): number => {
+    // CPP/OAS are 100% taxable. US Social Security received by a Canadian
+    // resident is included at 85% under the Canada–US tax treaty, matching
+    // the social_security stream treatment.
+    return governmentBenefitIncome + ssStreamIncome * 0.85;
   },
 
   getLowBracketFillTarget: (): number => {
@@ -142,13 +162,16 @@ export const CAConfig: CountryConfig = {
     return CANADIAN_PROVINCES;
   },
 
-  calculateRetirementBenefits: (profile: Profile, currentAge: number, grossIncome: number) => {
-    return calculateCanadianRetirementBenefits(profile, currentAge, grossIncome);
+  calculateRetirementBenefits: (profile: Profile, currentAge: number, meansTestIncome: number) => {
+    return calculateCanadianRetirementBenefits(profile, currentAge, meansTestIncome);
   },
 
-  getMinimumWithdrawal: (age: number, balance: number, accountType: string) => {
+  getMinimumWithdrawal: (age: number, balance: number, accountType: string, _birthYear?: number) => {
     return calculateRRIFMinimum(age, balance, accountType);
   },
+
+  // RRIF conversion age does not depend on birth year in Canada.
+  getRMDStartAge: (_birthYear: number) => RRIF_START_AGE,
 
   getDefaultProfile: () => ({
     country: 'CA' as const,

--- a/src/countries/canada/taxes.ts
+++ b/src/countries/canada/taxes.ts
@@ -1,9 +1,11 @@
 import type { TaxBracket } from '../../types';
+import { scaleBrackets } from '../../utils/taxBrackets';
 import {
   FEDERAL_TAX_BRACKETS,
   FEDERAL_BASIC_PERSONAL_AMOUNT,
   PROVINCIAL_TAX_BRACKETS,
   PROVINCIAL_BASIC_PERSONAL_AMOUNTS,
+  ONTARIO_SURTAX,
 } from './constants';
 
 /**
@@ -29,17 +31,25 @@ function calculateProgressiveTax(income: number, brackets: TaxBracket[]): number
 }
 
 /**
- * Calculate federal income tax (Canada)
+ * Calculate federal income tax (Canada).
+ *
+ * `indexFactor` scales bracket boundaries and the basic personal amount for
+ * future-year projections (both are indexed to inflation under current law);
+ * 1 = current year.
  */
-export function calculateFederalIncomeTax(income: number): number {
-  const taxableIncome = Math.max(0, income - FEDERAL_BASIC_PERSONAL_AMOUNT);
-  return calculateProgressiveTax(taxableIncome, FEDERAL_TAX_BRACKETS);
+export function calculateFederalIncomeTax(income: number, indexFactor: number = 1): number {
+  const taxableIncome = Math.max(0, income - FEDERAL_BASIC_PERSONAL_AMOUNT * indexFactor);
+  return calculateProgressiveTax(taxableIncome, scaleBrackets(FEDERAL_TAX_BRACKETS, indexFactor));
 }
 
 /**
  * Calculate provincial income tax
  */
-export function calculateProvincialIncomeTax(income: number, provinceCode: string): number {
+export function calculateProvincialIncomeTax(
+  income: number,
+  provinceCode: string,
+  indexFactor: number = 1
+): number {
   const brackets = PROVINCIAL_TAX_BRACKETS[provinceCode];
   const basicPersonalAmount = PROVINCIAL_BASIC_PERSONAL_AMOUNTS[provinceCode] || 0;
 
@@ -48,8 +58,22 @@ export function calculateProvincialIncomeTax(income: number, provinceCode: strin
     return 0;
   }
 
-  const taxableIncome = Math.max(0, income - basicPersonalAmount);
-  return calculateProgressiveTax(taxableIncome, brackets);
+  const taxableIncome = Math.max(0, income - basicPersonalAmount * indexFactor);
+  const basicTax = calculateProgressiveTax(taxableIncome, scaleBrackets(brackets, indexFactor));
+
+  // Ontario levies a surtax on basic provincial tax itself; without it the
+  // bracket rates alone substantially understate ON tax at higher incomes.
+  // Its thresholds are indexed annually, so scale them like the brackets.
+  if (provinceCode === 'ON') {
+    const t1 = ONTARIO_SURTAX.threshold1 * indexFactor;
+    const t2 = ONTARIO_SURTAX.threshold2 * indexFactor;
+    const surtax =
+      ONTARIO_SURTAX.rate1 * Math.max(0, basicTax - t1) +
+      ONTARIO_SURTAX.rate2 * Math.max(0, basicTax - t2);
+    return basicTax + surtax;
+  }
+
+  return basicTax;
 }
 
 /**

--- a/src/countries/canada/withdrawals.ts
+++ b/src/countries/canada/withdrawals.ts
@@ -16,11 +16,14 @@ export function getRRIFMinimumPercentage(age: number): number {
 }
 
 /**
- * Calculate RRIF minimum withdrawal
+ * Calculate RRIF minimum withdrawal.
+ *
+ * Applies to RRSP/RRIF (RRSP modeled as converted to RRIF at 71) and to
+ * LIRA/LIF, which must likewise convert by 71 and follow the same minimum
+ * table. LIF withdrawal MAXIMUMS are not modeled.
  */
 export function calculateRRIFMinimum(age: number, balance: number, accountType: string): number {
-  // RRIF minimums only apply to RRIF and RRSP accounts (after age 71)
-  if (accountType !== 'rrif' && accountType !== 'rrsp') return 0;
+  if (!isRRIFAccount(accountType)) return 0;
   if (age < RRIF_START_AGE) return 0;
   if (balance <= 0) return 0;
 
@@ -36,8 +39,14 @@ export function mustConvertRRSPToRRIF(age: number): boolean {
 }
 
 /**
- * Check if account type is subject to RRIF minimums
+ * Check if account type is subject to RRIF-style minimums after age 71.
+ * LIRA/LIF must convert to a LIF by 71 and follow the same minimum table.
  */
 export function isRRIFAccount(accountType: string): boolean {
-  return accountType === 'rrif' || accountType === 'rrsp';
+  return (
+    accountType === 'rrif' ||
+    accountType === 'rrsp' ||
+    accountType === 'lif' ||
+    accountType === 'lira'
+  );
 }

--- a/src/countries/index.ts
+++ b/src/countries/index.ts
@@ -68,23 +68,55 @@ export interface CountryConfig {
    * stack on ordinary income, inclusion/exclusion rates, standard
    * deductions / basic personal amounts, and regional tax treatment.
    *
-   * @param ordinaryIncome - Total ordinary taxable income for the year
-   * @param capitalGains - Total (pre-inclusion) capital gains for the year
+   * @param ordinaryIncome - Total ordinary taxable income for the year (nominal dollars)
+   * @param capitalGains - Total (pre-inclusion) capital gains for the year (nominal dollars)
    * @param profile - User profile (filing status, region, state tax rate, etc.)
-   * @returns Federal/national tax and regional/provincial tax owed
+   * @param indexFactor - Cumulative inflation multiplier for the simulated
+   *   year; scales brackets/deductions/personal amounts, which are indexed to
+   *   inflation under current law. Defaults to 1 (current tax year).
+   * @returns Federal/national tax, regional/provincial tax, and the taxable
+   *   income used (ordinary income plus the included portion of capital
+   *   gains, before deductions) — callers use it for benefit means-testing.
    */
   calculateYearlyTaxes: (
     ordinaryIncome: number,
     capitalGains: number,
-    profile: Profile
-  ) => { federalTax: number; regionalTax: number };
+    profile: Profile,
+    indexFactor?: number
+  ) => { federalTax: number; regionalTax: number; taxableIncome: number };
 
   /**
    * Get the portion of government retirement benefit income (e.g., Social
    * Security, CPP/OAS) that counts as taxable income.
+   *
+   * This flat rate is used as a planning ESTIMATE (e.g., in the
+   * bracket-fill step, before the year's withdrawals are known). The exact
+   * amount is computed afterwards by getTaxableGovernmentBenefits.
+   *
    * @returns Taxable rate as a decimal (e.g., 0.85 for US Social Security, 1.0 for Canada CPP/OAS)
    */
   getGovernmentBenefitTaxableRate: () => number;
+
+  /**
+   * Compute the exact taxable amount of retirement-benefit income for the
+   * year, once all other income is known.
+   *
+   * @param governmentBenefitIncome - Government benefits from the profile
+   *   (US Social Security, Canada CPP/OAS), nominal dollars
+   * @param ssStreamIncome - Income-stream income with the social_security
+   *   tax treatment, nominal dollars
+   * @param otherOrdinaryIncome - All other income counted when means-testing
+   *   benefit taxability (traditional withdrawals, pensions, other income,
+   *   capital gains), nominal dollars
+   * @param profile - User profile (filing status)
+   * @returns Total taxable income arising from both benefit pools
+   */
+  getTaxableGovernmentBenefits: (
+    governmentBenefitIncome: number,
+    ssStreamIncome: number,
+    otherOrdinaryIncome: number,
+    profile: Profile
+  ) => number;
 
   /**
    * Get the total ordinary income (in dollars) up to which additional
@@ -102,15 +134,21 @@ export interface CountryConfig {
 
   /**
    * Calculate government retirement benefits (Social Security, CPP, OAS, etc.)
+   *
+   * Benefit amounts are returned in today's dollars; the engine applies the
+   * inflation multiplier afterwards.
+   *
    * @param profile - User profile with benefit start ages and amounts
    * @param currentAge - Current age in the simulation
-   * @param grossIncome - Gross income for the year (for clawback calculations)
+   * @param meansTestIncome - Prior-year taxable income for means-testing
+   *   (e.g., OAS clawback), expressed in TODAY'S dollars so it compares
+   *   against current-year thresholds in like units
    * @returns Array of benefit calculations (e.g., CPP and OAS for Canada)
    */
   calculateRetirementBenefits: (
     profile: Profile,
     currentAge: number,
-    grossIncome: number
+    meansTestIncome: number
   ) => BenefitCalculation[];
 
   /**
@@ -118,9 +156,24 @@ export interface CountryConfig {
    * @param age - Current age
    * @param balance - Account balance
    * @param accountType - Type of account
+   * @param birthYear - Birth year, for rules where the start age depends on
+   *   it (US SECURE 2.0: RMDs at 73 if born before 1960, 75 otherwise).
+   *   When omitted, the earliest start age applies.
    * @returns Minimum withdrawal amount (0 if no requirement)
    */
-  getMinimumWithdrawal: (age: number, balance: number, accountType: string) => number;
+  getMinimumWithdrawal: (
+    age: number,
+    balance: number,
+    accountType: string,
+    birthYear?: number
+  ) => number;
+
+  /**
+   * Age at which mandatory minimum withdrawals (RMD/RRIF) begin for
+   * traditional accounts, for a person born in `birthYear`.
+   * US: 73 (born before 1960) or 75 (born 1960+); Canada: 71.
+   */
+  getRMDStartAge: (birthYear: number) => number;
 
   /**
    * Get default profile values for this country

--- a/src/countries/usa/benefits.ts
+++ b/src/countries/usa/benefits.ts
@@ -30,11 +30,5 @@ export function calculateSocialSecurityBenefits(
   return benefits;
 }
 
-/**
- * Calculate taxable portion of Social Security
- * US has up to 85% of SS taxable depending on income
- * Simplified: assumes 85% taxable
- */
-export function getTaxableSocialSecurity(socialSecurityBenefit: number): number {
-  return socialSecurityBenefit * 0.85;
-}
+// The taxable portion of Social Security is computed by
+// calculateTaxableSocialSecurity in ./taxes.ts (provisional-income phase-in).

--- a/src/countries/usa/constants.ts
+++ b/src/countries/usa/constants.ts
@@ -30,6 +30,15 @@ export const TAX_BRACKETS_SINGLE: TaxBracket[] = [
 export const STANDARD_DEDUCTION_MFJ = 32200;
 export const STANDARD_DEDUCTION_SINGLE = 16100;
 
+// Social Security taxability thresholds (provisional income). These are
+// FROZEN by statute — unlike brackets, they have never been indexed to
+// inflation — so projections must NOT scale them. Over long horizons this
+// means most retirees phase into the 85% maximum, which is current law.
+export const SS_TAXABILITY_THRESHOLDS = {
+  single: { base: 25000, upper: 34000 },
+  married_filing_jointly: { base: 32000, upper: 44000 },
+};
+
 // Long-term capital gains rates (2026)
 export const CAPITAL_GAINS_BRACKETS_MFJ: TaxBracket[] = [
   { min: 0, max: 98900, rate: 0 },
@@ -43,8 +52,14 @@ export const CAPITAL_GAINS_BRACKETS_SINGLE: TaxBracket[] = [
   { min: 545500, max: Infinity, rate: 0.20 },
 ];
 
-// RMD starts at age 73 (SECURE 2.0 Act)
+// RMD start age under the SECURE 2.0 Act: 73 for those born before 1960,
+// 75 for those born in 1960 or later (effective 2033). RMD_START_AGE is the
+// earliest possible start age; use getRMDStartAge for a specific person.
 export const RMD_START_AGE = 73;
+
+export function getRMDStartAge(birthYear: number): number {
+  return birthYear >= 1960 ? 75 : 73;
+}
 
 // IRS Uniform Lifetime Table
 export const RMD_TABLE: RMDEntry[] = [

--- a/src/countries/usa/index.ts
+++ b/src/countries/usa/index.ts
@@ -1,9 +1,9 @@
 import type { CountryConfig, AccountTypeConfig, Region, AccountGroup, PenaltyInfo } from '../index';
 import type { Profile } from '../../types';
-import { calculateTotalFederalTax, getStandardDeduction } from './taxes';
+import { calculateTotalFederalTax, getStandardDeduction, calculateTaxableSocialSecurity } from './taxes';
 import { calculateSocialSecurityBenefits } from './benefits';
 import { calculateRMD } from './withdrawals';
-import { US_STATES } from './constants';
+import { US_STATES, getRMDStartAge } from './constants';
 import { CHART_COLORS } from '../../utils/constants';
 import { calculateStateTax } from '../../utils/taxes';
 
@@ -88,21 +88,38 @@ export const USConfig: CountryConfig = {
   calculateYearlyTaxes: (
     ordinaryIncome: number,
     capitalGains: number,
-    profile: Profile
-  ): { federalTax: number; regionalTax: number } => {
+    profile: Profile,
+    indexFactor: number = 1
+  ): { federalTax: number; regionalTax: number; taxableIncome: number } => {
     const filingStatus = profile.filingStatus;
-    const federalTax = calculateTotalFederalTax(ordinaryIncome, capitalGains, filingStatus);
-    const standardDeduction = getStandardDeduction(filingStatus);
+    const federalTax = calculateTotalFederalTax(ordinaryIncome, capitalGains, filingStatus, indexFactor);
+    const standardDeduction = getStandardDeduction(filingStatus) * indexFactor;
     const regionalTax = calculateStateTax(
       ordinaryIncome + capitalGains - standardDeduction,
       profile.stateTaxRate || 0
     );
-    return { federalTax, regionalTax };
+    // Capital gains are fully includable for US income measurement purposes.
+    const taxableIncome = ordinaryIncome + capitalGains;
+    return { federalTax, regionalTax, taxableIncome };
   },
 
   getGovernmentBenefitTaxableRate: (): number => {
-    // US Social Security: up to 85% of benefits are taxable
+    // US Social Security: up to 85% of benefits are taxable. Used as a
+    // planning estimate; the exact amount comes from the provisional-income
+    // phase-in in getTaxableGovernmentBenefits.
     return 0.85;
+  },
+
+  getTaxableGovernmentBenefits: (
+    governmentBenefitIncome: number,
+    ssStreamIncome: number,
+    otherOrdinaryIncome: number,
+    profile: Profile
+  ): number => {
+    // Both pools are Social Security; apply the provisional-income
+    // phase-in (0% → 50% → 85%) to the combined benefit.
+    const totalSS = governmentBenefitIncome + ssStreamIncome;
+    return calculateTaxableSocialSecurity(totalSS, otherOrdinaryIncome, profile.filingStatus);
   },
 
   getLowBracketFillTarget: (filingStatus?: string): number => {
@@ -116,13 +133,15 @@ export const USConfig: CountryConfig = {
     return US_STATES;
   },
 
-  calculateRetirementBenefits: (profile: Profile, currentAge: number, grossIncome: number) => {
-    return calculateSocialSecurityBenefits(profile, currentAge, grossIncome);
+  calculateRetirementBenefits: (profile: Profile, currentAge: number, meansTestIncome: number) => {
+    return calculateSocialSecurityBenefits(profile, currentAge, meansTestIncome);
   },
 
-  getMinimumWithdrawal: (age: number, balance: number, accountType: string) => {
-    return calculateRMD(age, balance, accountType);
+  getMinimumWithdrawal: (age: number, balance: number, accountType: string, birthYear?: number) => {
+    return calculateRMD(age, balance, accountType, birthYear);
   },
+
+  getRMDStartAge: (birthYear: number) => getRMDStartAge(birthYear),
 
   getDefaultProfile: () => ({
     country: 'US' as const,

--- a/src/countries/usa/taxes.ts
+++ b/src/countries/usa/taxes.ts
@@ -1,4 +1,5 @@
 import type { TaxBracket } from '../../types';
+import { scaleBrackets } from '../../utils/taxBrackets';
 import {
   TAX_BRACKETS_MFJ,
   TAX_BRACKETS_SINGLE,
@@ -6,6 +7,7 @@ import {
   STANDARD_DEDUCTION_SINGLE,
   CAPITAL_GAINS_BRACKETS_MFJ,
   CAPITAL_GAINS_BRACKETS_SINGLE,
+  SS_TAXABILITY_THRESHOLDS,
 } from './constants';
 
 export function getTaxBrackets(filingStatus?: string): TaxBracket[] {
@@ -27,15 +29,19 @@ export function getCapitalGainsBrackets(filingStatus?: string): TaxBracket[] {
 }
 
 /**
- * Calculate federal income tax on ordinary income
+ * Calculate federal income tax on ordinary income.
+ *
+ * `indexFactor` scales bracket boundaries for future-year projections
+ * (brackets are indexed to inflation under current law); 1 = current year.
  */
 export function calculateFederalIncomeTax(
   taxableIncome: number,
-  filingStatus?: string
+  filingStatus?: string,
+  indexFactor: number = 1
 ): number {
   if (taxableIncome <= 0) return 0;
 
-  const brackets = getTaxBrackets(filingStatus);
+  const brackets = scaleBrackets(getTaxBrackets(filingStatus), indexFactor);
   let tax = 0;
   let remainingIncome = taxableIncome;
 
@@ -58,12 +64,13 @@ export function calculateFederalIncomeTax(
 export function calculateCapitalGainsTax(
   capitalGains: number,
   otherTaxableIncome: number,
-  filingStatus?: string
+  filingStatus?: string,
+  indexFactor: number = 1
 ): number {
   if (capitalGains <= 0) return 0;
 
-  const brackets = getCapitalGainsBrackets(filingStatus);
-  const standardDeduction = getStandardDeduction(filingStatus);
+  const brackets = scaleBrackets(getCapitalGainsBrackets(filingStatus), indexFactor);
+  const standardDeduction = getStandardDeduction(filingStatus) * indexFactor;
 
   const incomeBase = Math.max(0, otherTaxableIncome - standardDeduction);
 
@@ -93,18 +100,62 @@ export function calculateCapitalGainsTax(
 }
 
 /**
+ * Calculate the taxable portion of Social Security benefits using the
+ * provisional-income phase-in (IRC §86).
+ *
+ * Provisional income = other income + 50% of SS benefits. Below the base
+ * threshold none of SS is taxable; between base and upper up to 50% phases
+ * in; above upper up to 85% phases in.
+ *
+ * The thresholds are deliberately NOT inflation-indexed — they are frozen
+ * by statute — so nominal future incomes are compared against them as-is.
+ * Over long horizons this pushes most retirees to the 85% maximum, which
+ * matches current law.
+ *
+ * @param annualSS - Annual Social Security benefits (nominal dollars)
+ * @param otherIncome - All other income counted in provisional income
+ *   (ordinary income excluding SS, plus capital gains), nominal dollars
+ */
+export function calculateTaxableSocialSecurity(
+  annualSS: number,
+  otherIncome: number,
+  filingStatus?: string
+): number {
+  if (annualSS <= 0) return 0;
+
+  const thresholds = filingStatus === 'married_filing_jointly'
+    ? SS_TAXABILITY_THRESHOLDS.married_filing_jointly
+    : SS_TAXABILITY_THRESHOLDS.single;
+
+  const provisionalIncome = otherIncome + 0.5 * annualSS;
+
+  if (provisionalIncome <= thresholds.base) return 0;
+
+  if (provisionalIncome <= thresholds.upper) {
+    return Math.min(0.5 * (provisionalIncome - thresholds.base), 0.5 * annualSS);
+  }
+
+  const tier1 = Math.min(0.5 * (thresholds.upper - thresholds.base), 0.5 * annualSS);
+  return Math.min(
+    0.85 * (provisionalIncome - thresholds.upper) + tier1,
+    0.85 * annualSS
+  );
+}
+
+/**
  * Calculate total federal tax
  */
 export function calculateTotalFederalTax(
   ordinaryIncome: number,
   capitalGains: number,
-  filingStatus?: string
+  filingStatus?: string,
+  indexFactor: number = 1
 ): number {
-  const standardDeduction = getStandardDeduction(filingStatus);
+  const standardDeduction = getStandardDeduction(filingStatus) * indexFactor;
   const taxableOrdinaryIncome = Math.max(0, ordinaryIncome - standardDeduction);
 
-  const incomeTax = calculateFederalIncomeTax(taxableOrdinaryIncome, filingStatus);
-  const capitalGainsTax = calculateCapitalGainsTax(capitalGains, ordinaryIncome, filingStatus);
+  const incomeTax = calculateFederalIncomeTax(taxableOrdinaryIncome, filingStatus, indexFactor);
+  const capitalGainsTax = calculateCapitalGainsTax(capitalGains, ordinaryIncome, filingStatus, indexFactor);
 
   return incomeTax + capitalGainsTax;
 }

--- a/src/countries/usa/withdrawals.ts
+++ b/src/countries/usa/withdrawals.ts
@@ -1,7 +1,9 @@
-import { RMD_TABLE, RMD_START_AGE } from './constants';
+import { RMD_TABLE, RMD_START_AGE, getRMDStartAge } from './constants';
 
 /**
- * Get RMD divisor for a given age
+ * Get RMD divisor for a given age (IRS Uniform Lifetime Table lookup).
+ * Gated at the earliest possible RMD age; the caller applies the
+ * birth-year-specific start age via calculateRMD.
  */
 export function getRMDDivisor(age: number): number {
   if (age < RMD_START_AGE) return 0;
@@ -13,12 +15,22 @@ export function getRMDDivisor(age: number): number {
 }
 
 /**
- * Calculate Required Minimum Distribution
+ * Calculate Required Minimum Distribution.
+ *
+ * `birthYear` determines the start age under SECURE 2.0 (73 for those born
+ * before 1960, 75 for 1960 or later). When omitted, the earliest start age
+ * (73) is used.
  */
-export function calculateRMD(age: number, balance: number, accountType: string): number {
+export function calculateRMD(
+  age: number,
+  balance: number,
+  accountType: string,
+  birthYear?: number
+): number {
   // RMDs only apply to traditional (pretax) accounts
   if (!isTraditionalAccount(accountType)) return 0;
-  if (age < RMD_START_AGE) return 0;
+  const startAge = birthYear !== undefined ? getRMDStartAge(birthYear) : RMD_START_AGE;
+  if (age < startAge) return 0;
   if (balance <= 0) return 0;
 
   const divisor = getRMDDivisor(age);

--- a/src/hooks/useRetirementCalc.ts
+++ b/src/hooks/useRetirementCalc.ts
@@ -23,6 +23,7 @@ export function useRetirementCalc(
         finalBalances: {},
         totalAtRetirement: 0,
         breakdownByGroup: {},
+        finalCostBasis: {},
       };
     }
     return calculateAccumulation(accounts, profile, countryConfig);

--- a/src/tests/calculations.test.ts
+++ b/src/tests/calculations.test.ts
@@ -15,6 +15,7 @@ import {
   calculateCapitalGainsTax,
   getStandardDeduction,
 } from '../utils/taxes';
+import { calculateTaxableSocialSecurity } from '../countries/usa/taxes';
 import { getRMDDivisor } from '../utils/constants';
 import { Account, Profile, Assumptions, IncomeStream } from '../types';
 import { getCountryConfig } from '../countries';
@@ -767,9 +768,9 @@ function testWithdrawalStrategyDetails(): void {
 
   // Target spending is $20k (4% of $500k)
   // But the strategy should fill the 12% bracket
-  // Standard deduction: $29,200
-  // 12% bracket max: $94,300
-  // Total optimal: $29,200 + $94,300 = $123,500
+  // Standard deduction: $32,200
+  // 12% bracket max: $100,800
+  // Total optimal: $32,200 + $100,800 = $133,000
   // Since we only need $20k, withdrawal should be $20k (need-based, not bracket-filling beyond need)
   assertApprox(year1.totalWithdrawal, 20000, 1, 'Withdrawal matches target spending');
 
@@ -895,7 +896,7 @@ function testCostBasisTracking(): void {
     id: 'taxable',
     name: 'Taxable',
     type: 'taxable',
-    balance: 100000, // Will be treated as 50% cost basis by default
+    balance: 100000, // No costBasis set: defaults to full balance (no unrealized gains)
     annualContribution: 0,
     contributionGrowthRate: 0,
     returnRate: 0,
@@ -920,10 +921,69 @@ function testCostBasisTracking(): void {
 
   const year1 = result.yearlyWithdrawals[0];
 
-  // With $100k balance and 50% cost basis ($50k), gain ratio = 50%
-  // $10k withdrawal should have $5k gains
-  // Capital gains tax at 0% bracket (income below threshold) = $0
-  assert(year1.federalTax >= 0, 'Federal tax calculated for taxable account withdrawal');
+  // With no costBasis input and no growth, basis = full balance, so the
+  // withdrawal has no gains and no tax.
+  assertApprox(year1.federalTax, 0, 0.01, 'No gains (basis = balance) means no federal tax');
+
+  console.log('\n--- Explicit cost basis drives the gains portion ---');
+
+  // $5M balance, zero basis: everything withdrawn is gains. Compare with a
+  // full-basis account: same withdrawal, zero gains. The zero-basis account
+  // must pay more federal tax (capital gains above the 0% bracket).
+  const zeroBasisAccount: Account = {
+    ...taxableAccount,
+    id: 'taxable',
+    balance: 5000000,
+    costBasis: 0,
+  };
+  const fullBasisAccount: Account = {
+    ...taxableAccount,
+    id: 'taxable',
+    balance: 5000000,
+    // costBasis unset: defaults to full balance
+  };
+  const bigAssumptions: Assumptions = {
+    inflationRate: 0,
+    safeWithdrawalRate: 0.10, // $500k/yr withdrawal
+    retirementReturnRate: 0,
+  };
+  const zeroBasisResult = calculateWithdrawals(
+    [zeroBasisAccount], profile, bigAssumptions,
+    calculateAccumulation([zeroBasisAccount], profile, usConfig), usConfig
+  );
+  const fullBasisResult = calculateWithdrawals(
+    [fullBasisAccount], profile, bigAssumptions,
+    calculateAccumulation([fullBasisAccount], profile, usConfig), usConfig
+  );
+  const zeroBasisTax = zeroBasisResult.yearlyWithdrawals[0].federalTax;
+  const fullBasisTax = fullBasisResult.yearlyWithdrawals[0].federalTax;
+  assert(zeroBasisTax > 10000, `Zero-basis withdrawal is taxed as gains ($${zeroBasisTax.toFixed(0)})`);
+  assertApprox(fullBasisTax, 0, 0.01, 'Full-basis withdrawal has no gains and no tax');
+
+  console.log('\n--- Contributions add to basis during accumulation ---');
+
+  // $100k start (basis $40k), $10k/yr contribution for 2 years, no growth:
+  // basis at retirement = $40k + $10k + $10k = $60k; balance = $120k
+  const contributingAccount: Account = {
+    id: 'taxable',
+    name: 'Taxable',
+    type: 'taxable',
+    balance: 100000,
+    costBasis: 40000,
+    annualContribution: 10000,
+    contributionGrowthRate: 0,
+    returnRate: 0,
+  };
+  const accumProfile: Profile = {
+    currentAge: 63,
+    retirementAge: 65,
+    lifeExpectancy: 66,
+    filingStatus: 'married_filing_jointly',
+    stateTaxRate: 0,
+  };
+  const contribAccum = calculateAccumulation([contributingAccount], accumProfile, usConfig);
+  assertApprox(contribAccum.finalBalances['taxable'], 120000, 0.01, 'Balance = $120k after 2 years of contributions');
+  assertApprox(contribAccum.finalCostBasis?.['taxable'] ?? -1, 60000, 0.01, 'Basis = starting basis + contributions = $60k');
 
   console.log('\n--- Cost basis depletion over time ---');
 
@@ -1029,6 +1089,44 @@ function testRMDInteractions(): void {
 
   // RMD only on $1M traditional = $1M / 26.5 = $37,735.85
   assertApprox(mixedYear73.rmdAmount, 37735.85, 1, 'RMD only on traditional balance');
+
+  console.log('\n--- RMD start age depends on birth year (SECURE 2.0) ---');
+
+  // A retiree currently in their 40s was born after 1960, so RMDs start at
+  // 75, not 73. (Birth year is derived from current age.)
+  const currentYear = new Date().getFullYear();
+  const youngRetireeAge = 45; // Born ~currentYear - 45, well after 1960
+  assert(currentYear - youngRetireeAge >= 1960, 'Test precondition: 45-year-old is born 1960+');
+
+  const youngProfile: Profile = {
+    currentAge: youngRetireeAge,
+    retirementAge: 70,
+    lifeExpectancy: 80,
+    filingStatus: 'married_filing_jointly',
+    stateTaxRate: 0.05,
+  };
+  const youngAssumptions: Assumptions = {
+    inflationRate: 0,
+    safeWithdrawalRate: 0.01, // Low SWR so any forced withdrawal is RMD-driven
+    retirementReturnRate: 0,
+  };
+  const youngAccum = calculateAccumulation([largeTraditional], youngProfile, usConfig);
+  const youngResult = calculateWithdrawals([largeTraditional], youngProfile, youngAssumptions, youngAccum, usConfig);
+
+  const at73 = youngResult.yearlyWithdrawals.find(y => y.age === 73);
+  const at74 = youngResult.yearlyWithdrawals.find(y => y.age === 74);
+  const at75 = youngResult.yearlyWithdrawals.find(y => y.age === 75);
+  if (at73 && at74 && at75) {
+    assertApprox(at73.rmdAmount, 0, 0.01, 'No RMD at 73 for someone born 1960+');
+    assertApprox(at74.rmdAmount, 0, 0.01, 'No RMD at 74 for someone born 1960+');
+    assert(at75.rmdAmount > 0, `RMD starts at 75 for someone born 1960+ ($${at75.rmdAmount.toFixed(0)})`);
+    // Divisor at 75 is 24.6 from the Uniform Lifetime Table
+    const expectedRMD75 = at75.rmdAmount;
+    const balanceAt75 = youngResult.yearlyWithdrawals.find(y => y.age === 74)!.totalRemainingBalance;
+    assertApprox(expectedRMD75, balanceAt75 / 24.6, 1, 'RMD at 75 uses the age-75 divisor (24.6)');
+  } else {
+    assert(false, 'Missing withdrawal rows for ages 73-75');
+  }
 }
 
 // =============================================================================
@@ -1148,6 +1246,19 @@ function testPortfolioDepletion(): void {
     result.portfolioDepletionAge !== null && result.portfolioDepletionAge < 80,
     `Portfolio depletes at age ${result.portfolioDepletionAge} (before life expectancy)`
   );
+
+  // The reported depletion age is the first year with an unmet spending
+  // need — the year the money actually ran short, not the year after.
+  const firstShortfallYear = result.yearlyWithdrawals.find(y => y.spendingShortfall > 0);
+  assert(firstShortfallYear !== undefined, 'A shortfall year is recorded for a depleting portfolio');
+  if (firstShortfallYear) {
+    assertApprox(
+      firstShortfallYear.age,
+      result.portfolioDepletionAge ?? -1,
+      0.01,
+      'Depletion age equals the first year with a spending shortfall'
+    );
+  }
 
   console.log('\n--- Sustainable portfolio (no depletion) ---');
 
@@ -1438,6 +1549,298 @@ function testCanadianCalculations(): void {
 }
 
 // =============================================================================
+// CANADA PROVINCIAL FIDELITY TESTS
+// =============================================================================
+
+function testCanadaProvincialFidelity(): void {
+  section('CANADA PROVINCIAL FIDELITY (ON SURTAX, QC ABATEMENT, LIF)');
+
+  console.log('\n--- Ontario surtax ---');
+
+  const onProfile: Profile = {
+    country: 'CA', currentAge: 65, retirementAge: 65, lifeExpectancy: 90, region: 'ON',
+  };
+
+  // $150k ordinary income in Ontario:
+  // Taxable after $12,989 BPA = $137,011
+  // Basic ON tax: $53,891 @ 5.05% + $53,894 @ 9.15% + $29,226 @ 11.16% = $10,914.42
+  // Surtax: 20% x ($10,914.42 - $5,818) + 36% x ($10,914.42 - $7,446) = $2,267.92
+  // Total = $13,182.34
+  const onHigh = caConfig.calculateYearlyTaxes(150000, 0, onProfile);
+  assertApprox(onHigh.regionalTax, 13182.34, 0.5, 'ON provincial tax on $150k includes the surtax');
+
+  // $70k income: basic ON tax (~$3,007) is below the first surtax threshold,
+  // so no surtax applies (regression guard for the existing stacking test).
+  const onLow = caConfig.calculateYearlyTaxes(70000, 0, onProfile);
+  assertApprox(onLow.regionalTax, 3006.98, 0.5, 'ON provincial tax below surtax thresholds is unchanged');
+
+  console.log('\n--- Quebec federal abatement ---');
+
+  const qcProfile: Profile = { ...onProfile, region: 'QC' };
+  const onFederal = caConfig.calculateYearlyTaxes(100000, 0, onProfile).federalTax;
+  const qcFederal = caConfig.calculateYearlyTaxes(100000, 0, qcProfile).federalTax;
+  assertApprox(qcFederal, onFederal * 0.835, 0.01, 'QC federal tax is reduced by the 16.5% abatement');
+
+  console.log('\n--- LIF/LIRA minimum withdrawals ---');
+
+  const lifMin71 = caConfig.getMinimumWithdrawal(71, 100000, 'lif');
+  assertApprox(lifMin71, 5280, 10, 'LIF minimum at 71 = 5.28% of $100k');
+
+  const liraMin75 = caConfig.getMinimumWithdrawal(75, 100000, 'lira');
+  assertApprox(liraMin75, 5820, 10, 'LIRA minimum at 75 = 5.82% (modeled as converted to LIF)');
+
+  const lifMin70 = caConfig.getMinimumWithdrawal(70, 100000, 'lif');
+  assertApprox(lifMin70, 0, 0.01, 'No LIF minimum before age 71');
+
+  const tfsaMin = caConfig.getMinimumWithdrawal(75, 100000, 'tfsa');
+  assertApprox(tfsaMin, 0, 0.01, 'TFSA has no minimum withdrawal');
+}
+
+// =============================================================================
+// SOCIAL SECURITY TAXABILITY PHASE-IN TESTS
+// =============================================================================
+
+function testSocialSecurityPhaseIn(): void {
+  section('SOCIAL SECURITY TAXABILITY PHASE-IN');
+
+  console.log('\n--- Provisional income tiers (MFJ: base $32k, upper $44k) ---');
+
+  // PI = other + 50% SS. $30k SS alone: PI = $15k <= $32k base -> $0 taxable
+  const tier0 = calculateTaxableSocialSecurity(30000, 0, 'married_filing_jointly');
+  assertApprox(tier0, 0, 0.01, 'SS-only retiree below base threshold pays $0 SS tax');
+
+  // $30k SS + $25k other: PI = $40k, in 50% tier
+  // taxable = min(0.5 * (40000 - 32000), 0.5 * 30000) = $4,000
+  const tier1 = calculateTaxableSocialSecurity(30000, 25000, 'married_filing_jointly');
+  assertApprox(tier1, 4000, 0.01, '50% tier: $4,000 of $30k SS taxable with $25k other income');
+
+  // $30k SS + $60k other: PI = $75k > $44k upper
+  // tier1 = min(0.5 * 12000, 15000) = $6,000
+  // taxable = min(0.85 * (75000 - 44000) + 6000, 0.85 * 30000) = min($32,350, $25,500) = $25,500
+  const tier2 = calculateTaxableSocialSecurity(30000, 60000, 'married_filing_jointly');
+  assertApprox(tier2, 25500, 0.01, '85% cap: $25,500 of $30k SS taxable with $60k other income');
+
+  console.log('\n--- Single filer thresholds (base $25k, upper $34k) ---');
+
+  // $20k SS + $18k other: PI = $28k, 50% tier: min(0.5 * 3000, 10000) = $1,500
+  const single1 = calculateTaxableSocialSecurity(20000, 18000, 'single');
+  assertApprox(single1, 1500, 0.01, 'Single filer 50% tier calculation');
+
+  const singleZero = calculateTaxableSocialSecurity(20000, 10000, 'single');
+  assertApprox(singleZero, 0, 0.01, 'Single filer below base threshold pays $0');
+
+  console.log('\n--- Frozen thresholds: far-future nominal incomes hit 85% ---');
+
+  // Thresholds are not indexed, so decades of inflation push virtually any
+  // real income over them in nominal terms.
+  const future = calculateTaxableSocialSecurity(75000, 150000, 'married_filing_jointly');
+  assertApprox(future, 75000 * 0.85, 0.01, 'Large nominal future income caps at 85% taxable');
+
+  console.log('\n--- Engine: low-income retiree pays no federal tax on SS ---');
+
+  // Small Roth + modest SS stream: Roth withdrawals aren't income, so
+  // provisional income stays below the base threshold -> $0 federal tax.
+  const rothAccount: Account = {
+    id: 'roth',
+    name: 'Roth IRA',
+    type: 'roth_ira',
+    balance: 500000,
+    annualContribution: 0,
+    contributionGrowthRate: 0,
+    returnRate: 0,
+  };
+  const lowProfile: Profile = {
+    currentAge: 67,
+    retirementAge: 67,
+    lifeExpectancy: 70,
+    filingStatus: 'married_filing_jointly',
+    stateTaxRate: 0.05,
+  };
+  const lowAssumptions: Assumptions = {
+    inflationRate: 0,
+    safeWithdrawalRate: 0.04, // $20k/yr from Roth
+    retirementReturnRate: 0,
+  };
+  const ssStreams: IncomeStream[] = [
+    { id: 'ss', name: 'Social Security', monthlyAmount: 2000, startAge: 67, taxTreatment: 'social_security' },
+  ];
+  const lowAccum = calculateAccumulation([rothAccount], lowProfile, usConfig);
+  const lowResult = calculateWithdrawals([rothAccount], lowProfile, lowAssumptions, lowAccum, usConfig, ssStreams);
+  const lowYear = lowResult.yearlyWithdrawals[0];
+  // $24k SS, PI = $12k <= $32k base -> $0 taxable SS -> $0 federal tax
+  assertApprox(lowYear.federalTax, 0, 0.01, 'Roth + modest SS retiree pays $0 federal tax (was taxed at 85% flat before)');
+}
+
+// =============================================================================
+// INFLATION INDEXING TESTS
+// =============================================================================
+
+function testInflationIndexing(): void {
+  section('INFLATION INDEXING (BRACKETS & THRESHOLDS)');
+
+  console.log('\n--- Scaled brackets double tax for doubled income ---');
+
+  // With indexFactor 2, doubled nominal income should produce exactly
+  // doubled nominal tax (constant real tax).
+  const base = calculateFederalIncomeTax(50000, 'married_filing_jointly');
+  const indexed = calculateFederalIncomeTax(100000, 'married_filing_jointly', 2);
+  assertApprox(indexed, base * 2, 0.01, 'Federal income tax scales linearly with indexed brackets');
+
+  const baseTotal = calculateTotalFederalTax(100000, 50000, 'married_filing_jointly');
+  const indexedTotal = calculateTotalFederalTax(200000, 100000, 'married_filing_jointly', 2);
+  assertApprox(indexedTotal, baseTotal * 2, 0.01, 'Total federal tax (ordinary + gains) scales with index factor');
+
+  const caProfileON: Profile = {
+    country: 'CA',
+    currentAge: 65,
+    retirementAge: 65,
+    lifeExpectancy: 90,
+    region: 'ON',
+  };
+  const caBase = caConfig.calculateYearlyTaxes(60000, 20000, caProfileON);
+  const caIndexed = caConfig.calculateYearlyTaxes(120000, 40000, caProfileON, 2);
+  assertApprox(caIndexed.federalTax, caBase.federalTax * 2, 0.01, 'CA federal tax scales with index factor');
+  assertApprox(caIndexed.regionalTax, caBase.regionalTax * 2, 0.01, 'CA provincial tax scales with index factor');
+
+  console.log('\n--- taxableIncome returned for means-testing ---');
+
+  assertApprox(caBase.taxableIncome, 70000, 0.01, 'CA taxable income = ordinary + 50% of gains');
+  const usTaxes = usConfig.calculateYearlyTaxes(60000, 20000, {
+    country: 'US', currentAge: 65, retirementAge: 65, lifeExpectancy: 90,
+    region: 'CA', filingStatus: 'married_filing_jointly', stateTaxRate: 0,
+  });
+  assertApprox(usTaxes.taxableIncome, 80000, 0.01, 'US taxable income = ordinary + gains');
+
+  console.log('\n--- Constant real income means constant real tax ---');
+
+  // A retiree whose spending (and thus income) tracks inflation exactly
+  // should pay a constant tax in TODAY'S dollars — indexed brackets remove
+  // artificial bracket creep.
+  const account: Account = {
+    id: 'trad',
+    name: 'Traditional',
+    type: 'traditional_401k',
+    balance: 1500000,
+    annualContribution: 0,
+    contributionGrowthRate: 0,
+    returnRate: 0,
+  };
+  const profile: Profile = {
+    currentAge: 65,
+    retirementAge: 65,
+    lifeExpectancy: 72, // Stop before RMD age so income is purely spending-driven
+    filingStatus: 'married_filing_jointly',
+    stateTaxRate: 0.05,
+  };
+  const assumptions: Assumptions = {
+    inflationRate: 0.03,
+    safeWithdrawalRate: 0.04,
+    retirementReturnRate: 0.05,
+  };
+  const accum = calculateAccumulation([account], profile, usConfig);
+  const result = calculateWithdrawals([account], profile, assumptions, accum, usConfig);
+
+  const firstYear = result.yearlyWithdrawals[0];
+  const lastYear = result.yearlyWithdrawals[result.yearlyWithdrawals.length - 1];
+  const firstRealTax = firstYear.totalTax;
+  const lastRealTax = lastYear.totalTax / Math.pow(1.03, lastYear.age - 65);
+  assertApprox(lastRealTax, firstRealTax, firstRealTax * 0.01, 'Real tax constant across years for constant real income');
+
+  console.log('\n--- OAS clawback: constant real units over long horizons ---');
+
+  // A 35-year-old Canadian with modest real retirement income (well under
+  // the real clawback threshold) must keep FULL OAS even 50 years out.
+  // This is the regression test for the nominal-vs-today's-dollar mismatch
+  // that previously zeroed OAS for middle-income retirees by age ~73.
+  const oasAccount: Account = {
+    id: 'rrsp',
+    name: 'RRSP',
+    type: 'rrsp',
+    balance: 300000,
+    annualContribution: 10000,
+    contributionGrowthRate: 0.02,
+    returnRate: 0.06,
+  };
+  const oasProfile: Profile = {
+    country: 'CA',
+    currentAge: 35,
+    retirementAge: 65,
+    lifeExpectancy: 90,
+    region: 'ON',
+    socialSecurityBenefit: 0, // No CPP, isolate OAS
+    socialSecurityStartAge: 65,
+    secondaryBenefitStartAge: 65,
+    secondaryBenefitAmount: OAS_MAX_MONTHLY * 12,
+  };
+  const oasAssumptions: Assumptions = {
+    inflationRate: 0.03,
+    safeWithdrawalRate: 0.04,
+    retirementReturnRate: 0.05,
+  };
+  const oasAccum = calculateAccumulation([oasAccount], oasProfile, caConfig);
+  const oasResult = calculateWithdrawals([oasAccount], oasProfile, oasAssumptions, oasAccum, caConfig, []);
+
+  const fullOAS = OAS_MAX_MONTHLY * 12;
+  const age85 = oasResult.yearlyWithdrawals.find(y => y.age === 85);
+  assert(age85 !== undefined, 'Has data at age 85');
+  if (age85) {
+    const oasReal85 = age85.governmentBenefitIncome / Math.pow(1.03, 85 - 35);
+    assertApprox(oasReal85, fullOAS, 1, `Mid-income retiree keeps full OAS at 85 (real $${oasReal85.toFixed(0)})`);
+  }
+
+  // A genuinely high-real-income retiree ($200k+ real) must still be
+  // clawed back, decades in the future.
+  const richAccount: Account = {
+    ...oasAccount,
+    id: 'rrsp-rich',
+    balance: 1500000,
+    annualContribution: 50000,
+  };
+  const richAccum = calculateAccumulation([richAccount], oasProfile, caConfig);
+  const richResult = calculateWithdrawals([richAccount], oasProfile, oasAssumptions, richAccum, caConfig, []);
+  const richAge75 = richResult.yearlyWithdrawals.find(y => y.age === 75);
+  if (richAge75) {
+    const oasRealRich = richAge75.governmentBenefitIncome / Math.pow(1.03, 75 - 35);
+    assert(oasRealRich < fullOAS - 1, `High-real-income retiree still clawed back (real OAS $${oasRealRich.toFixed(0)} < $${fullOAS.toFixed(0)})`);
+  }
+
+  console.log('\n--- TFSA withdrawals do not trigger OAS clawback ---');
+
+  // Tax-free withdrawals are not income for clawback purposes. From year 2
+  // on (year 1 uses the target-spending estimate), a TFSA-funded retiree
+  // keeps full OAS despite large withdrawals.
+  const tfsaAccount: Account = {
+    id: 'tfsa',
+    name: 'TFSA',
+    type: 'tfsa',
+    balance: 3000000,
+    annualContribution: 0,
+    contributionGrowthRate: 0,
+    returnRate: 0,
+  };
+  const tfsaProfile: Profile = {
+    country: 'CA',
+    currentAge: 71,
+    retirementAge: 71,
+    lifeExpectancy: 75,
+    region: 'ON',
+    socialSecurityBenefit: 0,
+    socialSecurityStartAge: 65,
+    secondaryBenefitStartAge: 65,
+    secondaryBenefitAmount: OAS_MAX_MONTHLY * 12,
+  };
+  const tfsaAssumptions: Assumptions = {
+    inflationRate: 0,
+    safeWithdrawalRate: 0.04, // $120k/yr spending, all from TFSA
+    retirementReturnRate: 0,
+  };
+  const tfsaAccum = calculateAccumulation([tfsaAccount], tfsaProfile, caConfig);
+  const tfsaResult = calculateWithdrawals([tfsaAccount], tfsaProfile, tfsaAssumptions, tfsaAccum, caConfig, []);
+  const tfsaYear2 = tfsaResult.yearlyWithdrawals[1];
+  assertApprox(tfsaYear2.governmentBenefitIncome, fullOAS, 0.01, 'TFSA-funded retiree keeps full OAS (year 2+)');
+}
+
+// =============================================================================
 // EARLY WITHDRAWAL PENALTY TESTS
 // =============================================================================
 
@@ -1708,11 +2111,16 @@ function testWithdrawalDefaults(): void {
     returnRate: 0.07,
   };
 
-  const defaultAge1 = getDefaultWithdrawalAge(usTraditionalAccount, 65, usConfig);
+  // Born 1950: RMD age 73
+  const defaultAge1 = getDefaultWithdrawalAge(usTraditionalAccount, 65, usConfig, 1950);
   assertApprox(defaultAge1, 60, 0.01, 'US traditional IRA defaults to age 60');
 
-  const maxAge1 = getMaxWithdrawalAge(usTraditionalAccount, 90, usConfig);
-  assertApprox(maxAge1, 73, 0.01, 'US traditional IRA max age is 73 (RMD age)');
+  const maxAge1 = getMaxWithdrawalAge(usTraditionalAccount, 90, usConfig, 1950);
+  assertApprox(maxAge1, 73, 0.01, 'US traditional IRA max age is 73 (born before 1960)');
+
+  // Born 1960 or later: RMD age 75 (SECURE 2.0)
+  const maxAge1b = getMaxWithdrawalAge(usTraditionalAccount, 90, usConfig, 1990);
+  assertApprox(maxAge1b, 75, 0.01, 'US traditional IRA max age is 75 (born 1960 or later)');
 
   console.log('\n--- US Roth Account Defaults ---');
 
@@ -1726,10 +2134,10 @@ function testWithdrawalDefaults(): void {
     returnRate: 0.07,
   };
 
-  const defaultAge2 = getDefaultWithdrawalAge(usRothAccount, 65, usConfig);
+  const defaultAge2 = getDefaultWithdrawalAge(usRothAccount, 65, usConfig, 1990);
   assertApprox(defaultAge2, 65, 0.01, 'US Roth IRA defaults to retirement age');
 
-  const maxAge2 = getMaxWithdrawalAge(usRothAccount, 90, usConfig);
+  const maxAge2 = getMaxWithdrawalAge(usRothAccount, 90, usConfig, 1990);
   assertApprox(maxAge2, 90, 0.01, 'US Roth IRA max age is life expectancy');
 
   console.log('\n--- Canada RRSP Defaults ---');
@@ -1745,11 +2153,11 @@ function testWithdrawalDefaults(): void {
     returnRate: 0.07,
   };
 
-  const defaultAge3 = getDefaultWithdrawalAge(caRRSPAccount, 65, caConfig);
+  const defaultAge3 = getDefaultWithdrawalAge(caRRSPAccount, 65, caConfig, 1990);
   assertApprox(defaultAge3, 65, 0.01, 'Canadian RRSP defaults to retirement age');
 
-  const maxAge3 = getMaxWithdrawalAge(caRRSPAccount, 90, caConfig);
-  assertApprox(maxAge3, 71, 0.01, 'Canadian RRSP max age is 71 (RRIF conversion age)');
+  const maxAge3 = getMaxWithdrawalAge(caRRSPAccount, 90, caConfig, 1990);
+  assertApprox(maxAge3, 71, 0.01, 'Canadian RRSP max age is 71 (RRIF conversion age, any birth year)');
 }
 
 // =============================================================================
@@ -2024,6 +2432,9 @@ function runAllTests(): void {
   testPortfolioDepletion();
   testTotalFederalTaxIntegration();
   testCanadianCalculations();
+  testCanadaProvincialFidelity();
+  testSocialSecurityPhaseIn();
+  testInflationIndexing();
   testWithdrawalWithConfigurableAge();
   testWithdrawalDefaults();
   testEarlyWithdrawalPenalties();

--- a/src/tests/export.test.ts
+++ b/src/tests/export.test.ts
@@ -528,6 +528,46 @@ function testScenarioRoundTrip(): void {
     JSON.stringify(testIncomeStreams),
     'Income streams survive the round trip unchanged'
   );
+
+  // Taxable-account cost basis is an optional field: it round-trips when
+  // present and stays undefined when absent (older files).
+  const taxableAccount: Account = {
+    id: 'acc-taxable',
+    name: 'Brokerage',
+    type: 'taxable',
+    balance: 80000,
+    annualContribution: 5000,
+    contributionGrowthRate: 0,
+    returnRate: 0.06,
+    withdrawalRules: { startAge: 65 },
+    costBasis: 55000,
+  };
+  const basisScenario = buildScenario(
+    {
+      country: 'US',
+      profile: testProfile,
+      accounts: [taxableAccount],
+      incomeStreams: [],
+      assumptions: testAssumptions,
+    },
+    FIXED_DATE
+  );
+  const basisResult = parseScenario(JSON.stringify(basisScenario));
+  if (basisResult.ok) {
+    assertEqual(basisResult.scenario.accounts[0].costBasis, 55000, 'Cost basis survives the round trip');
+    const noBasis = { ...taxableAccount } as Partial<Account>;
+    delete noBasis.costBasis;
+    const noBasisResult = parseScenario(
+      JSON.stringify({ ...basisScenario, accounts: [noBasis] })
+    );
+    if (noBasisResult.ok) {
+      assertEqual(noBasisResult.scenario.accounts[0].costBasis, undefined, 'Accounts without cost basis still load');
+    } else {
+      assert(false, `Accounts without cost basis still load (error: ${noBasisResult.error})`);
+    }
+  } else {
+    assert(false, `Cost basis scenario parses (error: ${basisResult.error})`);
+  }
   assertEqual(
     result.scenario.profile.currentAge,
     testProfile.currentAge,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -109,6 +109,10 @@ export interface Account {
   employerMatchPercent?: number; // 401k only, as decimal
   employerMatchLimit?: number; // 401k only, dollar amount
   withdrawalRules?: AccountWithdrawalRules;  // Optional for backwards compatibility
+  // Taxable accounts only: amount originally invested (for capital gains).
+  // Defaults to the full current balance when unset. Contributions made
+  // during the accumulation phase are added to it automatically.
+  costBasis?: number;
 }
 
 export interface Profile {
@@ -144,6 +148,11 @@ export interface AccumulationResult {
   finalBalances: Record<string, number>;
   totalAtRetirement: number;
   breakdownByGroup: Record<string, number>; // Flexible groupings defined by country
+  // Cost basis at retirement for taxable accounts: starting basis plus all
+  // contributions made during accumulation. Optional so mock results without
+  // an accumulation phase still work; the engine falls back to the account's
+  // own costBasis (or full balance) when absent.
+  finalCostBasis?: Record<string, number>;
 }
 
 export interface YearlyWithdrawal {
@@ -164,6 +173,9 @@ export interface YearlyWithdrawal {
   totalRemainingBalance: number;
   earlyWithdrawalPenalties: EarlyWithdrawalPenalty[];
   totalPenalties: number;
+  // Portion of target spending the portfolio + income could not cover this
+  // year (0 when the target was fully met).
+  spendingShortfall: number;
 }
 
 export interface RetirementResult {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -15,6 +15,7 @@ export {
   RMD_START_AGE,
   RMD_TABLE,
   getRMDDivisor,
+  getRMDStartAge,
 } from '../countries/usa/constants';
 
 // Chart colors

--- a/src/utils/export/realDollars.ts
+++ b/src/utils/export/realDollars.ts
@@ -9,6 +9,10 @@
  *
  * Anything that presents "today's dollars" must divide by the inflation factor
  * for that year — see SummaryCards and the CSV/print exports.
+ *
+ * Tax brackets, deductions, and benefit thresholds are indexed by the same
+ * inflation assumption inside the engine, so deflated tax figures reflect
+ * constant real tax policy rather than artificial bracket creep.
  */
 
 /**

--- a/src/utils/export/scenario.ts
+++ b/src/utils/export/scenario.ts
@@ -160,6 +160,7 @@ function parseAccount(value: unknown, index: number): Account {
     ),
     employerMatchLimit: optionalNum(value.employerMatchLimit, `${label}.employerMatchLimit`),
     withdrawalRules: parsedRules,
+    costBasis: optionalNum(value.costBasis, `${label}.costBasis`),
   };
 }
 

--- a/src/utils/export/tables.ts
+++ b/src/utils/export/tables.ts
@@ -279,6 +279,7 @@ export function buildWithdrawalTable(
         totalTax: yearData.totalTax,
         afterTaxIncome: yearData.afterTaxIncome,
         afterTaxIncomeReal: yearData.afterTaxIncome / factor,
+        shortfall: yearData.spendingShortfall,
         inflationFactor: factor,
       };
     });
@@ -300,6 +301,7 @@ export function buildWithdrawalTable(
         (sum, y) => sum + y.afterTaxIncome / factorFor(y.age),
         0
       ),
+      shortfall: years.reduce((sum, y) => sum + y.spendingShortfall, 0),
       inflationFactor: null,
     };
 
@@ -316,6 +318,7 @@ export function buildWithdrawalTable(
         { key: 'totalTax', label: 'Total Taxes', type: 'currency' },
         { key: 'afterTaxIncome', label: 'After-Tax Income', type: 'currency' },
         { key: 'afterTaxIncomeReal', label: 'After-Tax Income (Real)', type: 'currency' },
+        { key: 'shortfall', label: 'Spending Shortfall', type: 'currency' },
         FACTOR_COLUMN,
       ],
       rows,

--- a/src/utils/projections.ts
+++ b/src/utils/projections.ts
@@ -4,6 +4,7 @@ import {
   AccumulationResult,
   YearlyAccountBalance,
   is401k,
+  getTaxTreatment,
 } from '../types';
 import type { CountryConfig } from '../countries';
 
@@ -50,10 +51,17 @@ export function calculateAccumulation(
   // Initialize balances
   const balances: Record<string, number> = {};
   const contributions: Record<string, number> = {};
+  // Taxable accounts: track cost basis (starting basis + contributions) so
+  // the withdrawal phase can compute the gains portion of withdrawals.
+  const costBasis: Record<string, number> = {};
 
   accounts.forEach(account => {
     balances[account.id] = account.balance;
     contributions[account.id] = account.annualContribution;
+    if (getTaxTreatment(account.type) === 'taxable') {
+      // Default: today's balance is all basis (no unrealized gains yet).
+      costBasis[account.id] = Math.min(account.costBasis ?? account.balance, account.balance);
+    }
   });
 
   const yearlyBalances: YearlyAccountBalance[] = [];
@@ -85,6 +93,11 @@ export function calculateAccumulation(
 
       // Update balance
       balances[account.id] = balanceAfterReturn + totalContribution;
+
+      // Contributions to taxable accounts are after-tax money: add to basis
+      if (account.id in costBasis) {
+        costBasis[account.id] += totalContribution;
+      }
 
       // 3. Grow contribution for next year
       contributions[account.id] = currentContribution * (1 + account.contributionGrowthRate);
@@ -125,5 +138,6 @@ export function calculateAccumulation(
     finalBalances: { ...balances },
     totalAtRetirement: Object.values(balances).reduce((sum, b) => sum + b, 0),
     breakdownByGroup,
+    finalCostBasis: { ...costBasis },
   };
 }

--- a/src/utils/taxBrackets.ts
+++ b/src/utils/taxBrackets.ts
@@ -1,0 +1,19 @@
+import type { TaxBracket } from '../types';
+
+/**
+ * Scale a bracket table's boundaries by an indexation factor.
+ *
+ * The projection engine works in nominal (future) dollars while bracket
+ * constants are defined in current-tax-year dollars. Both US and Canadian
+ * law index brackets, deductions, and basic personal amounts to inflation
+ * annually, so projections scale them by the cumulative inflation multiplier
+ * for the simulated year. A factor of 1 returns the table unchanged.
+ */
+export function scaleBrackets(brackets: TaxBracket[], factor: number): TaxBracket[] {
+  if (factor === 1) return brackets;
+  return brackets.map(bracket => ({
+    min: bracket.min * factor,
+    max: bracket.max === Infinity ? Infinity : bracket.max * factor,
+    rate: bracket.rate,
+  }));
+}

--- a/src/utils/taxes.ts
+++ b/src/utils/taxes.ts
@@ -23,9 +23,10 @@ export function getCapitalGainsBrackets(filingStatus: FilingStatus): TaxBracket[
  */
 export function calculateFederalIncomeTax(
   taxableIncome: number,
-  filingStatus: FilingStatus
+  filingStatus: FilingStatus,
+  indexFactor: number = 1
 ): number {
-  return usaTaxes.calculateFederalIncomeTax(taxableIncome, filingStatus);
+  return usaTaxes.calculateFederalIncomeTax(taxableIncome, filingStatus, indexFactor);
 }
 
 /**
@@ -35,9 +36,10 @@ export function calculateFederalIncomeTax(
 export function calculateCapitalGainsTax(
   capitalGains: number,
   otherTaxableIncome: number,
-  filingStatus: FilingStatus
+  filingStatus: FilingStatus,
+  indexFactor: number = 1
 ): number {
-  return usaTaxes.calculateCapitalGainsTax(capitalGains, otherTaxableIncome, filingStatus);
+  return usaTaxes.calculateCapitalGainsTax(capitalGains, otherTaxableIncome, filingStatus, indexFactor);
 }
 
 /**
@@ -46,9 +48,10 @@ export function calculateCapitalGainsTax(
 export function calculateTotalFederalTax(
   ordinaryIncome: number, // Traditional withdrawals, SS, etc.
   capitalGains: number, // Growth portion of taxable account withdrawals
-  filingStatus: FilingStatus
+  filingStatus: FilingStatus,
+  indexFactor: number = 1
 ): number {
-  return usaTaxes.calculateTotalFederalTax(ordinaryIncome, capitalGains, filingStatus);
+  return usaTaxes.calculateTotalFederalTax(ordinaryIncome, capitalGains, filingStatus, indexFactor);
 }
 
 /**

--- a/src/utils/withdrawalDefaults.ts
+++ b/src/utils/withdrawalDefaults.ts
@@ -12,12 +12,15 @@ import type { CountryConfig } from '../countries';
  * @param account - The account to get default for
  * @param retirementAge - User's planned retirement age
  * @param countryConfig - Country configuration
+ * @param birthYear - User's birth year; determines the RMD start age
+ *   (US: 73 if born before 1960, 75 otherwise; Canada: 71)
  * @returns Default withdrawal start age
  */
 export function getDefaultWithdrawalAge(
   account: Account,
   retirementAge: number,
-  countryConfig: CountryConfig
+  countryConfig: CountryConfig,
+  birthYear: number
 ): number {
   const penaltyInfo = countryConfig.getPenaltyInfo(account.type);
 
@@ -25,9 +28,8 @@ export function getDefaultWithdrawalAge(
   // Check if account requires RMDs by seeing if getMinimumWithdrawal returns > 0 at RMD age
   let rmdAge: number | undefined;
   if (countryConfig.isTraditionalAccount(account.type)) {
-    // US RMD age is 73, Canada RRIF age is 71
-    const testAge = countryConfig.code === 'US' ? 73 : 71;
-    const testRmd = countryConfig.getMinimumWithdrawal(testAge, 100000, account.type);
+    const testAge = countryConfig.getRMDStartAge(birthYear);
+    const testRmd = countryConfig.getMinimumWithdrawal(testAge, 100000, account.type, birthYear);
     if (testRmd > 0) {
       rmdAge = testAge;
     }
@@ -51,17 +53,19 @@ export function getDefaultWithdrawalAge(
  * @param account - The account to check
  * @param lifeExpectancy - User's life expectancy
  * @param countryConfig - Country configuration
+ * @param birthYear - User's birth year; determines the RMD start age
  * @returns Maximum withdrawal age
  */
 export function getMaxWithdrawalAge(
   account: Account,
   lifeExpectancy: number,
-  countryConfig: CountryConfig
+  countryConfig: CountryConfig,
+  birthYear: number
 ): number {
   // Check if this account type requires RMDs
   if (countryConfig.isTraditionalAccount(account.type)) {
-    const rmdAge = countryConfig.code === 'US' ? 73 : 71;
-    const testRmd = countryConfig.getMinimumWithdrawal(rmdAge, 100000, account.type);
+    const rmdAge = countryConfig.getRMDStartAge(birthYear);
+    const testRmd = countryConfig.getMinimumWithdrawal(rmdAge, 100000, account.type, birthYear);
     if (testRmd > 0) {
       return rmdAge; // Cannot delay withdrawal past RMD age
     }
@@ -69,4 +73,13 @@ export function getMaxWithdrawalAge(
 
   // Otherwise, can delay until life expectancy
   return lifeExpectancy;
+}
+
+/**
+ * Approximate birth year from the user's current age. Off by at most one
+ * year (depending on whether their birthday has passed), which only matters
+ * for the RMD-age boundary cohort (born ~1959/1960).
+ */
+export function birthYearFromAge(currentAge: number): number {
+  return new Date().getFullYear() - currentAge;
 }

--- a/src/utils/withdrawals.ts
+++ b/src/utils/withdrawals.ts
@@ -14,10 +14,10 @@ import {
   calculateStateTax,
   getStandardDeduction,
 } from './taxes';
-import { getRMDDivisor, RMD_START_AGE } from './constants';
+import { getRMDDivisor, getRMDStartAge } from './constants';
 import type { CountryConfig } from '../countries';
 import { calculatePenalties, type AccountWithdrawal } from './penaltyCalculator';
-import { getDefaultWithdrawalAge } from './withdrawalDefaults';
+import { getDefaultWithdrawalAge, birthYearFromAge } from './withdrawalDefaults';
 import { calculateIncomeStreamBenefits } from './incomeStreams';
 
 interface AccountState {
@@ -35,13 +35,14 @@ function calculateRMD(
   age: number,
   traditionalBalance: number,
   accountType: string,
+  birthYear: number,
   countryConfig?: CountryConfig
 ): number {
   if (countryConfig) {
-    return countryConfig.getMinimumWithdrawal(age, traditionalBalance, accountType);
+    return countryConfig.getMinimumWithdrawal(age, traditionalBalance, accountType, birthYear);
   }
-  // Fallback to US RMD logic
-  if (age < RMD_START_AGE) return 0;
+  // Fallback to US RMD logic (SECURE 2.0: start age depends on birth year)
+  if (age < getRMDStartAge(birthYear)) return 0;
   const divisor = getRMDDivisor(age);
   if (divisor <= 0) return 0;
   return traditionalBalance / divisor;
@@ -55,6 +56,7 @@ function getAvailableAccounts(
   accounts: Account[],
   currentAge: number,
   retirementAge: number,
+  birthYear: number,
   countryConfig?: CountryConfig
 ): AccountState[] {
   return accountStates.filter(state => {
@@ -65,7 +67,7 @@ function getAvailableAccounts(
     // Get withdrawal start age (from rules or default)
     const withdrawalAge = account.withdrawalRules?.startAge ??
       (countryConfig
-        ? getDefaultWithdrawalAge(account, retirementAge, countryConfig)
+        ? getDefaultWithdrawalAge(account, retirementAge, countryConfig, birthYear)
         : retirementAge);
 
     return currentAge >= withdrawalAge;
@@ -86,27 +88,44 @@ export function calculateWithdrawals(
   const retirementYears = profile.lifeExpectancy - profile.retirementAge;
   const currentYear = new Date().getFullYear();
   const retirementStartYear = currentYear + (profile.retirementAge - profile.currentAge);
+  // Birth year determines the RMD start age (US SECURE 2.0: 73 vs 75)
+  const birthYear = birthYearFromAge(profile.currentAge);
 
   // Initialize account states with final balances from accumulation
-  const accountStates: AccountState[] = accounts.map(account => ({
-    id: account.id,
-    type: account.type,
-    balance: accumulationResult.finalBalances[account.id] || 0,
-    // For taxable accounts, estimate cost basis as original balance + contributions
-    // (simplified: assume 50% of balance is gains)
-    costBasis: getTaxTreatment(account.type) === 'taxable'
-      ? (accumulationResult.finalBalances[account.id] || 0) * 0.5
-      : 0,
-  }));
+  const accountStates: AccountState[] = accounts.map(account => {
+    const finalBalance = accumulationResult.finalBalances[account.id] || 0;
+    // Taxable accounts: cost basis tracked through accumulation (starting
+    // basis + contributions). Fall back to the account's own basis — or its
+    // full balance — for results without an accumulation phase. Basis is
+    // capped at the balance so the gains portion can't go negative.
+    const trackedBasis =
+      accumulationResult.finalCostBasis?.[account.id] ??
+      account.costBasis ??
+      account.balance;
+    return {
+      id: account.id,
+      type: account.type,
+      balance: finalBalance,
+      costBasis: getTaxTreatment(account.type) === 'taxable'
+        ? Math.min(trackedBasis, finalBalance)
+        : 0,
+    };
+  });
 
   // Calculate initial target spending based on safe withdrawal rate
   const totalPortfolio = accumulationResult.totalAtRetirement;
   let targetSpending = totalPortfolio * assumptions.safeWithdrawalRate;
 
-  // Gross income from the previous simulated year, used for benefit
-  // means-testing (e.g., OAS clawback). For the first retirement year,
-  // approximate using that year's target spending.
-  let previousYearGrossIncome = targetSpending;
+  // Taxable income from the previous simulated year, expressed in TODAY'S
+  // dollars, used for benefit means-testing (e.g., OAS clawback). Deflating
+  // to today's dollars keeps the comparison against current-year thresholds
+  // in like units — the thresholds are indexed to inflation in law. For the
+  // first retirement year, approximate using that year's target spending.
+  const retirementInflationMultiplier = Math.pow(
+    1 + assumptions.inflationRate,
+    profile.retirementAge - profile.currentAge
+  );
+  let previousYearTaxableIncomeToday = targetSpending / retirementInflationMultiplier;
 
   // Portion of government retirement benefit income (Social Security,
   // CPP/OAS) that counts as taxable income. US: 85%, Canada: 100%.
@@ -127,7 +146,9 @@ export function calculateWithdrawals(
     const age = profile.retirementAge + i;
     const year = retirementStartYear + i;
 
-    // Check if portfolio is depleted
+    // Fallback depletion check: balance already at zero entering the year
+    // (e.g., spending fully covered by benefits). The primary signal is the
+    // first year with a spending shortfall, recorded after withdrawals.
     const totalRemaining = accountStates.reduce((sum, acc) => sum + acc.balance, 0);
     if (totalRemaining <= 0 && portfolioDepletionAge === null) {
       portfolioDepletionAge = age;
@@ -140,10 +161,10 @@ export function calculateWithdrawals(
     // Calculate government retirement benefits (Social Security, CPP/OAS, etc.)
     let governmentBenefits = 0;
     if (countryConfig) {
-      // Use the prior simulated year's gross income for means-testing
-      // (e.g., OAS clawback). For the first retirement year, this is
-      // approximated using that year's target spending.
-      const benefits = countryConfig.calculateRetirementBenefits(profile, age, previousYearGrossIncome);
+      // Use the prior simulated year's taxable income, in today's dollars,
+      // for means-testing (e.g., OAS clawback). For the first retirement
+      // year, this is approximated using that year's target spending.
+      const benefits = countryConfig.calculateRetirementBenefits(profile, age, previousYearTaxableIncomeToday);
       governmentBenefits = benefits.reduce((sum, b) => sum + b.annualAmount, 0);
       // Adjust for inflation
       governmentBenefits *= inflationMultiplier;
@@ -183,12 +204,17 @@ export function calculateWithdrawals(
     accountStates
       .filter(acc => isTraditionalAccount(acc.type))
       .forEach(acc => {
-        const minWithdrawal = calculateRMD(age, acc.balance, acc.type, countryConfig);
+        const minWithdrawal = calculateRMD(age, acc.balance, acc.type, birthYear, countryConfig);
         totalMinimumWithdrawal += minWithdrawal;
       });
     const rmdAmount = totalMinimumWithdrawal;
 
-    // Pre-compute non-portfolio taxable income for bracket-filling logic
+    // Pre-compute non-portfolio taxable income for bracket-filling logic.
+    // This uses the flat maximum rate for benefit income (US: 85%) as a
+    // planning ESTIMATE — the exact US taxable portion depends on the
+    // year's other income (provisional-income phase-in), which isn't known
+    // until withdrawals are decided. Slightly overestimating here just
+    // makes the bracket-fill step a touch conservative.
     const nonPortfolioTaxableIncome =
       governmentBenefitIncome * governmentBenefitTaxableRate +
       inflatedStreamByTax.social_security * 0.85 +
@@ -205,9 +231,18 @@ export function calculateWithdrawals(
       profile,
       accountDepletionAges,
       age,
+      birthYear,
       countryConfig,
-      nonPortfolioTaxableIncome
+      nonPortfolioTaxableIncome,
+      inflationMultiplier
     );
+
+    // The year the portfolio first fails to cover target spending is the
+    // depletion year (previously this was reported one year late, at the
+    // first year that STARTED at zero).
+    if (withdrawals.shortfall > 0 && portfolioDepletionAge === null) {
+      portfolioDepletionAge = age;
+    }
 
     // Calculate early withdrawal penalties
     const penalties = countryConfig
@@ -221,38 +256,64 @@ export function calculateWithdrawals(
     });
 
     // Calculate taxes using country-specific logic
-    // Government benefits (US Social Security: 85% taxable; Canada CPP/OAS: 100% taxable)
-    const governmentBenefitTaxable = governmentBenefitIncome * governmentBenefitTaxableRate;
     // Income streams: per-bucket tax rules
-    const ssStreamTaxable = inflatedStreamByTax.social_security * 0.85;
     const pensionTaxable = inflatedStreamByTax.fully_taxable;
     const otherIncomeTaxable = inflatedStreamByTax.other_income;
     // tax_free: excluded from taxable income
 
-    const ordinaryIncome = withdrawals.traditionalWithdrawal +
-      governmentBenefitTaxable + ssStreamTaxable + pensionTaxable + otherIncomeTaxable;
     const capitalGains = withdrawals.taxableGains;
+
+    // Exact taxable portion of benefit income, now that this year's
+    // withdrawals are known. (The bracket-fill step above used the flat
+    // 85% ESTIMATE via nonPortfolioTaxableIncome; the US provisional-income
+    // phase-in depends on other income, which wasn't known yet at that
+    // point.) US: 0% → 50% → 85% phase-in against frozen thresholds;
+    // Canada: CPP/OAS 100%, social_security streams at the 85% treaty rate.
+    const otherIncomeForBenefitTax = withdrawals.traditionalWithdrawal +
+      pensionTaxable + otherIncomeTaxable + capitalGains;
+    const benefitTaxable = countryConfig
+      ? countryConfig.getTaxableGovernmentBenefits(
+          governmentBenefitIncome,
+          inflatedStreamByTax.social_security,
+          otherIncomeForBenefitTax,
+          profile
+        )
+      : (governmentBenefitIncome + inflatedStreamByTax.social_security) * 0.85;
+
+    const ordinaryIncome = withdrawals.traditionalWithdrawal +
+      benefitTaxable + pensionTaxable + otherIncomeTaxable;
 
     let federalTax: number;
     let stateTax: number;
+    let yearTaxableIncome: number;
 
     if (countryConfig) {
       // Use the country's consolidated tax calculation, which handles
       // capital gains stacking, inclusion rates, and regional tax rules.
-      const taxes = countryConfig.calculateYearlyTaxes(ordinaryIncome, capitalGains, profile);
+      // Brackets/deductions are indexed by the year's inflation multiplier.
+      const taxes = countryConfig.calculateYearlyTaxes(
+        ordinaryIncome,
+        capitalGains,
+        profile,
+        inflationMultiplier
+      );
       federalTax = taxes.federalTax;
       stateTax = taxes.regionalTax;
+      yearTaxableIncome = taxes.taxableIncome;
     } else {
       // Fallback to US logic
       federalTax = calculateTotalFederalTax(
         ordinaryIncome,
         capitalGains,
-        profile.filingStatus || 'single'
+        profile.filingStatus || 'single',
+        inflationMultiplier
       );
       stateTax = calculateStateTax(
-        ordinaryIncome + capitalGains - getStandardDeduction(profile.filingStatus || 'single'),
+        ordinaryIncome + capitalGains -
+          getStandardDeduction(profile.filingStatus || 'single') * inflationMultiplier,
         profile.stateTaxRate || 0
       );
+      yearTaxableIncome = ordinaryIncome + capitalGains;
     }
     const totalTax = federalTax + stateTax + totalPenalties;
     lifetimeTaxesPaid += totalTax;
@@ -285,11 +346,14 @@ export function calculateWithdrawals(
       totalRemainingBalance: accountStates.reduce((sum, acc) => sum + acc.balance, 0),
       earlyWithdrawalPenalties: penalties,
       totalPenalties,
+      spendingShortfall: withdrawals.shortfall,
     });
 
-    // Track this year's gross income for next year's benefit means-testing
-    // (e.g., OAS clawback)
-    previousYearGrossIncome = grossIncome;
+    // Track this year's taxable income, deflated to today's dollars, for
+    // next year's benefit means-testing (e.g., OAS clawback). Taxable
+    // income — not gross — so tax-free withdrawals (TFSA, Roth) don't
+    // trigger clawback.
+    previousYearTaxableIncomeToday = yearTaxableIncome / inflationMultiplier;
 
     // Inflate target spending for next year
     targetSpending *= (1 + assumptions.inflationRate);
@@ -320,6 +384,7 @@ interface WithdrawalResult {
   hsaWithdrawal: number;
   byAccount: Record<string, number>;
   accountWithdrawals: AccountWithdrawal[];  // NEW: for penalty calculation
+  shortfall: number; // Unmet spending need after every withdrawal source is exhausted
 }
 
 /**
@@ -338,8 +403,10 @@ function performTaxOptimizedWithdrawal(
   profile: Profile,
   accountDepletionAges: Record<string, number | null>,
   age: number,
+  birthYear: number,
   countryConfig?: CountryConfig,
-  nonPortfolioTaxableIncome?: number
+  nonPortfolioTaxableIncome?: number,
+  inflationMultiplier: number = 1
 ): WithdrawalResult {
   const result: WithdrawalResult = {
     total: 0,
@@ -350,6 +417,7 @@ function performTaxOptimizedWithdrawal(
     hsaWithdrawal: 0,
     byAccount: {},
     accountWithdrawals: [],  // NEW
+    shortfall: 0,
   };
 
   accountStates.forEach(acc => {
@@ -378,6 +446,7 @@ function performTaxOptimizedWithdrawal(
     accounts,
     age,
     profile.retirementAge,
+    birthYear,
     countryConfig
   );
 
@@ -415,10 +484,13 @@ function performTaxOptimizedWithdrawal(
 
   // Step 2: Fill up to the low tax bracket with additional traditional withdrawals
   // (country-specific target balances tax efficiency against future tax torpedo risk)
+  // The fill target is defined in current-year dollars, so index it by the
+  // year's inflation multiplier to match the (indexed) brackets it fills.
   const filingStatus = profile.filingStatus || 'single';
-  const targetOrdinaryIncome = countryConfig
+  const baseFillTarget = countryConfig
     ? countryConfig.getLowBracketFillTarget(filingStatus)
     : getStandardDeduction(filingStatus) + (filingStatus === 'married_filing_jointly' ? 100800 : 50400);
+  const targetOrdinaryIncome = baseFillTarget * inflationMultiplier;
   const currentOrdinaryIncome = result.traditionalWithdrawal +
     (nonPortfolioTaxableIncome || 0);
   const roomInBracket = Math.max(0, targetOrdinaryIncome - currentOrdinaryIncome);
@@ -533,7 +605,7 @@ function performTaxOptimizedWithdrawal(
 
       const withdrawalAge = account.withdrawalRules?.startAge ??
         (countryConfig
-          ? getDefaultWithdrawalAge(account, profile.retirementAge, countryConfig)
+          ? getDefaultWithdrawalAge(account, profile.retirementAge, countryConfig, birthYear)
           : profile.retirementAge);
 
       return age < withdrawalAge && state.balance > 0;
@@ -594,5 +666,6 @@ function performTaxOptimizedWithdrawal(
     }
   }
 
+  result.shortfall = Math.max(0, remainingNeed);
   return result;
 }


### PR DESCRIPTION
## Summary

A comprehensive review of the calculation engine found two genuinely misleading bugs and several fidelity gaps. This PR fixes all of them.

### Correctness fixes

- **OAS clawback unit mismatch (severe)** — The clawback compared *nominal future* income against the fixed 2026 threshold, then subtracted the nominal clawback from *un-inflated* OAS. A retiree with a constant real income of ~$44.6k (half the real threshold) lost 100% of OAS by age 73. Clawback math now runs entirely in today's dollars against prior-year **taxable** income, so TFSA/Roth withdrawals no longer trigger it either. Repro now shows full OAS at every age.
- **RMD start age by birth year** — Was hardcoded at 73; under SECURE 2.0, anyone born 1960+ (every user currently ≤66) starts at 75. Now derived from birth year and threaded through the engine, withdrawal-age defaults/validation, and the methodology panel. Canada stays at 71.
- **Inflation-indexed tax parameters** — Brackets, deductions, basic personal amounts, and the OAS threshold now grow with the assumed inflation rate (matching how both countries index them in law), removing artificial bracket creep that badly overstated taxes over 30–50 year horizons. Implemented via an `indexFactor` on `calculateYearlyTaxes` and a shared `scaleBrackets` helper.
- **Social Security taxability phase-in** — Replaces the flat 85% with the real provisional-income rule (0% → 50% → 85%). Its thresholds are **frozen by statute** and deliberately not indexed. The bracket-fill planning step still estimates at 85% (exact taxability depends on withdrawals not yet decided); the exact amount is computed for the actual tax bill.
- **Real cost-basis tracking** — Taxable accounts get an optional Cost Basis input (defaults to full current balance) and contributions accumulate into basis during projection, replacing the old "50% of balance at retirement" guess. Scenario files round-trip the new field; older files load unchanged (no schema bump).
- **Canada provincial fidelity** — Ontario surtax (20%/36% above $5,818/$7,446, per CRA's Jan 2026 payroll tables), Quebec's 16.5% federal abatement, and LIF/LIRA now follow RRIF minimums from age 71. LIF maximums and the ON Health Premium are disclosed as unmodeled.

### Presentation

- Depletion age now reports the first year spending actually falls short (was one year late), via a new `spendingShortfall` field, with a Shortfall column in the income export.
- Lifetime effective tax rate is now dollar-weighted (lifetime tax ÷ lifetime income), matching the CSV footer.
- Methodology panel updated for all of the above; stale "15% bracket" text and outdated 2024 figures in test comments fixed.
- Verified CPP ($1,507.65) and OAS ($742.31) 2026 defaults against official ESDC figures — already correct.

## Test plan

- `npm test` — 314 assertions passing (was 190), including new regression tests: OAS constant-real-units over 50-year horizons, TFSA no-clawback, RMD at 73 vs 75 by birth year, SS phase-in tiers (0/50/85%), indexed-bracket linearity, constant-real-tax invariance, ON surtax / QC abatement / LIF minimums, cost-basis accumulation and scenario round-trip, shortfall = depletion year.
- `npm run build` and `npm run lint` clean.
- Manually verified in the browser: methodology panel renders new disclosures; RMD shows 75 for the default 35-year-old profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)